### PR TITLE
Use DeviceEntryType.SERVICE

### DIFF
--- a/custom_components/blitzortung/sensor.py
+++ b/custom_components/blitzortung/sensor.py
@@ -2,6 +2,7 @@ import logging
 
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, LENGTH_KILOMETERS
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.device_registry import DeviceEntryType
 
 from .const import (
     ATTR_LAT,
@@ -123,7 +124,7 @@ class BlitzortungSensor(Entity):
             "identifiers": {(DOMAIN, self._integration_name)},
             "model": "Lightning Detector",
             "sw_version": "0.0.1",
-            "entry_type": "service",
+            "entry_type": DeviceEntryType.SERVICE,
         }
 
     def update_lightning(self, lightning):


### PR DESCRIPTION
Use DeviceEntryType.SERVICE as "service" is deprecated and will be removed. Triggers warning and error in 2021.12beta.