### PR TITLE
Fix sensor unit handling

### DIFF
--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -7,6 +7,7 @@ import time
 
 import voluptuous as vol
 
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -235,8 +236,8 @@ class BlitzortungCoordinator:
         distance = round(math.sqrt(dx * dx + dy * dy) * 6371, 1)
         azimuth = round(math.atan2(dx, dy) * 180 / math.pi) % 360
 
-        lightning[const.ATTR_LIGHTNING_DISTANCE] = distance
-        lightning[const.ATTR_LIGHTNING_AZIMUTH] = azimuth
+        lightning[SensorDeviceClass.DISTANCE] = distance
+        lightning[SensorDeviceClass.DISTANCE] = azimuth
 
     async def connect(self):
         await self.mqtt_client.async_connect()

--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -293,7 +293,7 @@ class BlitzortungCoordinator:
             lightning = json.loads(message.payload)
             self.compute_polar_coords(lightning)
             if lightning[SensorDeviceClass.DISTANCE] < self.radius:
-                _LOGGER.debug("ligntning data: %s", lightning)
+                _LOGGER.debug("lightning data: %s", lightning)
                 self.last_time = time.time()
                 for callback in self.lightning_callbacks:
                     callback(lightning)

--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -9,17 +9,13 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, UnitOfLength
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import async_track_time_interval
 
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 from homeassistant.util.unit_conversion import DistanceConverter
-from homeassistant.const import (
-    LENGTH_KILOMETERS,
-    LENGTH_MILES,
-)
 from . import const
 from .const import (
     CONF_IDLE_RESET_TIMEOUT,
@@ -76,7 +72,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
 
     if hass.config.units == IMPERIAL_SYSTEM:
         radius_mi = radius
-        radius = DistanceConverter.convert(radius, LENGTH_MILES, LENGTH_KILOMETERS)
+        radius = DistanceConverter.convert(radius, UnitOfLength.MILES, UnitOfLength.KILOMETERS)
         _LOGGER.info("imperial system, %s mi -> %s km", radius_mi, radius)
 
     coordinator = BlitzortungCoordinator(

--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -296,7 +296,7 @@ class BlitzortungCoordinator:
         if message.topic.startswith("blitzortung/1.1"):
             lightning = json.loads(message.payload)
             self.compute_polar_coords(lightning)
-            if lightning[const.ATTR_LIGHTNING_DISTANCE] < self.radius:
+            if lightning[SensorDeviceClass.DISTANCE] < self.radius:
                 _LOGGER.debug("ligntning data: %s", lightning)
                 self.last_time = time.time()
                 for callback in self.lightning_callbacks:

--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -286,7 +286,7 @@ class BlitzortungCoordinator:
                     notification_id="blitzortung_new_version_available",
                 )
 
-    def on_mqtt_message(self, message, *args):
+    async def on_mqtt_message(self, message, *args):
         for callback in self.callbacks:
             callback(message)
         if message.topic.startswith("blitzortung/1.1"):
@@ -296,7 +296,7 @@ class BlitzortungCoordinator:
                 _LOGGER.debug("lightning data: %s", lightning)
                 self.last_time = time.time()
                 for callback in self.lightning_callbacks:
-                    callback(lightning)
+                    await callback(lightning)
                 for sensor in self.sensors:
                     sensor.update_lightning(lightning)
 

--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -237,7 +237,7 @@ class BlitzortungCoordinator:
         azimuth = round(math.atan2(dx, dy) * 180 / math.pi) % 360
 
         lightning[SensorDeviceClass.DISTANCE] = distance
-        lightning[SensorDeviceClass.DISTANCE] = azimuth
+        lightning[const.ATTR_LIGHTNING_AZIMUTH] = azimuth
 
     async def connect(self):
         await self.mqtt_client.async_connect()

--- a/custom_components/blitzortung/const.py
+++ b/custom_components/blitzortung/const.py
@@ -6,7 +6,6 @@ PLATFORMS = ["sensor", "geo_location"]
 
 DOMAIN = "blitzortung"
 DATA_UNSUBSCRIBE = "unsubscribe"
-ATTR_LIGHTNING_DISTANCE = "distance"
 ATTR_LIGHTNING_AZIMUTH = "azimuth"
 ATTR_LIGHTNING_COUNTER = "counter"
 

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -101,7 +101,7 @@ class BlitzortungEventManager:
         else:
             self._unit = UnitOfLength.KILOMETERS
 
-    def lightning_cb(self, lightning):
+    async def lightning_cb(self, lightning):
         _LOGGER.debug("geo_location lightning: %s", lightning)
         event = BlitzortungEvent(
             lightning["distance"],

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -7,8 +7,7 @@ import uuid
 from homeassistant.components.geo_location import GeolocationEvent
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
-    LENGTH_KILOMETERS,
-    LENGTH_MILES,
+    UnitOfLength
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (
@@ -98,9 +97,9 @@ class BlitzortungEventManager:
         self._window_seconds = window_seconds
 
         if hass.config.units == IMPERIAL_SYSTEM:
-            self._unit = LENGTH_MILES
+            self._unit = UnitOfLength.MILES
         else:
-            self._unit = LENGTH_KILOMETERS
+            self._unit = UnitOfLength.KILOMETERS
 
     def lightning_cb(self, lightning):
         _LOGGER.debug("geo_location lightning: %s", lightning)


### PR DESCRIPTION
Did some general cleanup around the handling of constants in order to resolve #79 while removing some of the custom constants that duplicated built-in constants.

Removed all instances that manually updated the entity state and replaced them with updates to native_value instead allowing Home Assistant to actually perform unit conversions resolving #80 