### PR TITLE
Enable statistics for distance sensor

### DIFF
--- a/custom_components/blitzortung/sensor.py
+++ b/custom_components/blitzortung/sensor.py
@@ -1,7 +1,7 @@
 import logging
 
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, DEGREE, UnitOfLength
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.helpers.device_registry import DeviceEntryType
 
 from .const import (
@@ -144,6 +144,7 @@ class LightningSensor(BlitzortungSensor):
 class DistanceSensor(LightningSensor):
     kind = SensorDeviceClass.DISTANCE
     device_class = SensorDeviceClass.DISTANCE
+    state_class = SensorStateClass.MEASUREMENT
     _attr_native_unit_of_measurement = UnitOfLength.KILOMETERS
 
     def update_lightning(self, lightning):


### PR DESCRIPTION
Sets `state_class` for distance sensor to `measurement`, enabling Home Assistant to create long-term statistics.

See [New sensor properties for long-term statistics](https://developers.home-assistant.io/blog/2021/05/25/sensor_attributes/#state_class) and [Sensor Entity / Available state classes](https://developers.home-assistant.io/docs/core/entity/sensor/#available-state-classes) for reference.

This fixes #77 