### PR TITLE
Store coordinator in `config_entry.runtime_data` and use `HassKey` for config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,135 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# Home Assistant
+.HA_VERSION
+*.yaml
+home-assistant*
+.storage

--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 from homeassistant.util.unit_conversion import DistanceConverter
 from . import const
 from .const import (
+    BLITZORTUNG_CONFIG,
     CONF_IDLE_RESET_TIMEOUT,
     CONF_MAX_TRACKED_LIGHTNINGS,
     CONF_RADIUS,
@@ -45,15 +46,13 @@ BlitzortungConfigEntry = ConfigEntry["BlitzortungCoordinator"]
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Initialize basic config of blitzortung component."""
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN]["config"] = config.get(DOMAIN) or {}
+    hass.data[BLITZORTUNG_CONFIG] = config.get(DOMAIN) or {}
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: BlitzortungConfigEntry):
     """Set up blitzortung from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-    config = hass.data[DOMAIN].get("config") or {}
+    config = hass.data[BLITZORTUNG_CONFIG]
 
     latitude = config_entry.options.get(CONF_LATITUDE, hass.config.latitude)
     longitude = config_entry.options.get(CONF_LONGITUDE, hass.config.longitude)

--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -1,5 +1,4 @@
 """The blitzortung integration."""
-import asyncio
 import json
 import logging
 import math
@@ -40,6 +39,113 @@ CONFIG_SCHEMA = vol.Schema(
     {DOMAIN: vol.Schema({vol.Optional(const.SERVER_STATS, default=False): bool})},
     extra=vol.ALLOW_EXTRA,
 )
+
+BlitzortungConfigEntry = ConfigEntry["BlitzortungCoordinator"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Initialize basic config of blitzortung component."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN]["config"] = config.get(DOMAIN) or {}
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, config_entry: BlitzortungConfigEntry):
+    """Set up blitzortung from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    config = hass.data[DOMAIN].get("config") or {}
+
+    latitude = config_entry.options.get(CONF_LATITUDE, hass.config.latitude)
+    longitude = config_entry.options.get(CONF_LONGITUDE, hass.config.longitude)
+    radius = config_entry.options.get(CONF_RADIUS, DEFAULT_RADIUS)
+    max_tracked_lightnings = config_entry.options.get(
+        CONF_MAX_TRACKED_LIGHTNINGS, DEFAULT_MAX_TRACKED_LIGHTNINGS
+    )
+    time_window_seconds = (
+        config_entry.options.get(CONF_TIME_WINDOW, DEFAULT_TIME_WINDOW) * 60
+    )
+    if max_tracked_lightnings >= 500:
+        _LOGGER.warning(
+            "Large number of tracked lightnings: %s, it may lead to"
+            "bigger memory usage / unstable frontend",
+            max_tracked_lightnings,
+        )
+
+    if hass.config.units == IMPERIAL_SYSTEM:
+        radius_mi = radius
+        radius = DistanceConverter.convert(radius, UnitOfLength.MILES, UnitOfLength.KILOMETERS)
+        _LOGGER.info("imperial system, %s mi -> %s km", radius_mi, radius)
+
+    coordinator = BlitzortungCoordinator(
+        hass,
+        latitude,
+        longitude,
+        radius,
+        max_tracked_lightnings,
+        time_window_seconds,
+        DEFAULT_UPDATE_INTERVAL,
+        server_stats=config.get(const.SERVER_STATS),
+    )
+
+    config_entry.runtime_data = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
+    await coordinator.connect()
+
+    if not config_entry.update_listeners:
+        config_entry.add_update_listener(async_update_options)
+
+    return True
+
+
+async def async_update_options(hass, config_entry: BlitzortungConfigEntry):
+    """Update options."""
+    _LOGGER.info("async_update_options")
+    await hass.config_entries.async_reload(config_entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: BlitzortungConfigEntry):
+    """Unload a config entry."""
+    coordinator = config_entry.runtime_data
+    await coordinator.disconnect()
+    _LOGGER.debug("Disconnected")
+
+    # Cleanup platforms.
+    if unload_ok := await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS):
+        # Pop coordinator only when unload was succesfull.
+        hass.data[DOMAIN].pop(config_entry.entry_id)
+
+    return unload_ok
+
+
+async def async_migrate_entry(hass, entry: BlitzortungConfigEntry):
+    _LOGGER.debug("Migrating Blitzortung entry from Version %s", entry.version)
+    if entry.version == 1:
+        latitude = entry.data[CONF_LATITUDE]
+        longitude = entry.data[CONF_LONGITUDE]
+        radius = entry.data[CONF_RADIUS]
+        name = entry.data[CONF_NAME]
+
+        entry.unique_id = f"{latitude}-{longitude}-{name}-lightning"
+        entry.data = {CONF_NAME: name}
+        entry.options = {
+            CONF_LATITUDE: latitude,
+            CONF_LONGITUDE: longitude,
+            CONF_RADIUS: radius,
+        }
+        entry.version = 2
+    if entry.version == 2:
+        entry.options = dict(entry.options)
+        entry.options[CONF_IDLE_RESET_TIMEOUT] = DEFAULT_IDLE_RESET_TIMEOUT
+        entry.version = 3
+    if entry.version == 3:
+        entry.options = dict(entry.options)
+        entry.options[CONF_TIME_WINDOW] = entry.options.pop(
+            CONF_IDLE_RESET_TIMEOUT, DEFAULT_TIME_WINDOW
+        )
+        entry.version = 4
+
+    return True
 
 
 class BlitzortungCoordinator:
@@ -211,111 +317,3 @@ class BlitzortungCoordinator:
     async def _tick(self, *args):
         for cb in self.on_tick_callbacks:
             cb()
-
-
-BlitzortungConfigEntry = ConfigEntry[BlitzortungCoordinator]
-
-
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Initialize basic config of blitzortung component."""
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN]["config"] = config.get(DOMAIN) or {}
-    return True
-
-
-async def async_setup_entry(hass: HomeAssistant, config_entry: BlitzortungConfigEntry):
-    """Set up blitzortung from a config entry."""
-    hass.data.setdefault(DOMAIN, {})
-    config = hass.data[DOMAIN].get("config") or {}
-
-    latitude = config_entry.options.get(CONF_LATITUDE, hass.config.latitude)
-    longitude = config_entry.options.get(CONF_LONGITUDE, hass.config.longitude)
-    radius = config_entry.options.get(CONF_RADIUS, DEFAULT_RADIUS)
-    max_tracked_lightnings = config_entry.options.get(
-        CONF_MAX_TRACKED_LIGHTNINGS, DEFAULT_MAX_TRACKED_LIGHTNINGS
-    )
-    time_window_seconds = (
-        config_entry.options.get(CONF_TIME_WINDOW, DEFAULT_TIME_WINDOW) * 60
-    )
-    if max_tracked_lightnings >= 500:
-        _LOGGER.warning(
-            "Large number of tracked lightnings: %s, it may lead to"
-            "bigger memory usage / unstable frontend",
-            max_tracked_lightnings,
-        )
-
-    if hass.config.units == IMPERIAL_SYSTEM:
-        radius_mi = radius
-        radius = DistanceConverter.convert(radius, UnitOfLength.MILES, UnitOfLength.KILOMETERS)
-        _LOGGER.info("imperial system, %s mi -> %s km", radius_mi, radius)
-
-    coordinator = BlitzortungCoordinator(
-        hass,
-        latitude,
-        longitude,
-        radius,
-        max_tracked_lightnings,
-        time_window_seconds,
-        DEFAULT_UPDATE_INTERVAL,
-        server_stats=config.get(const.SERVER_STATS),
-    )
-
-    config_entry.runtime_data = coordinator
-
-    await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-    await coordinator.connect()
-
-    if not config_entry.update_listeners:
-        config_entry.add_update_listener(async_update_options)
-
-    return True
-
-
-async def async_update_options(hass, config_entry: BlitzortungConfigEntry):
-    """Update options."""
-    _LOGGER.info("async_update_options")
-    await hass.config_entries.async_reload(config_entry.entry_id)
-
-
-async def async_unload_entry(hass: HomeAssistant, config_entry: BlitzortungConfigEntry):
-    """Unload a config entry."""
-    coordinator: BlitzortungCoordinator = config_entry.runtime_data
-    await coordinator.disconnect()
-    _LOGGER.debug("Disconnected")
-
-    # Cleanup platforms.
-    if unload_ok := await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS):
-        # Pop coordinator only when unload was succesfull.
-        hass.data[DOMAIN].pop(config_entry.entry_id)
-
-    return unload_ok
-
-
-async def async_migrate_entry(hass, entry: BlitzortungConfigEntry):
-    _LOGGER.debug("Migrating Blitzortung entry from Version %s", entry.version)
-    if entry.version == 1:
-        latitude = entry.data[CONF_LATITUDE]
-        longitude = entry.data[CONF_LONGITUDE]
-        radius = entry.data[CONF_RADIUS]
-        name = entry.data[CONF_NAME]
-
-        entry.unique_id = f"{latitude}-{longitude}-{name}-lightning"
-        entry.data = {CONF_NAME: name}
-        entry.options = {
-            CONF_LATITUDE: latitude,
-            CONF_LONGITUDE: longitude,
-            CONF_RADIUS: radius,
-        }
-        entry.version = 2
-    if entry.version == 2:
-        entry.options = dict(entry.options)
-        entry.options[CONF_IDLE_RESET_TIMEOUT] = DEFAULT_IDLE_RESET_TIMEOUT
-        entry.version = 3
-    if entry.version == 3:
-        entry.options = dict(entry.options)
-        entry.options[CONF_TIME_WINDOW] = entry.options.pop(
-            CONF_IDLE_RESET_TIMEOUT, DEFAULT_TIME_WINDOW
-        )
-        entry.version = 4
-
-    return True

--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -106,16 +106,10 @@ async def async_update_options(hass, config_entry: BlitzortungConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: BlitzortungConfigEntry):
     """Unload a config entry."""
-    coordinator = config_entry.runtime_data
-    await coordinator.disconnect()
+    await config_entry.runtime_data.disconnect()
     _LOGGER.debug("Disconnected")
 
-    # Cleanup platforms.
-    if unload_ok := await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS):
-        # Pop coordinator only when unload was succesfull.
-        hass.data[DOMAIN].pop(config_entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(config_entry, PLATFORMS)
 
 
 async def async_migrate_entry(hass, entry: BlitzortungConfigEntry):

--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -75,7 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: BlitzortungConfig
         radius = DistanceConverter.convert(radius, UnitOfLength.MILES, UnitOfLength.KILOMETERS)
         _LOGGER.info("imperial system, %s mi -> %s km", radius_mi, radius)
 
-    coordinator = BlitzortungCoordinator(
+    config_entry.runtime_data = BlitzortungCoordinator(
         hass,
         latitude,
         longitude,
@@ -86,10 +86,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: BlitzortungConfig
         server_stats=config.get(const.SERVER_STATS),
     )
 
-    config_entry.runtime_data = coordinator
-
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
-    await coordinator.connect()
+    await config_entry.runtime_data.connect()
 
     if not config_entry.update_listeners:
         config_entry.add_update_listener(async_update_options)

--- a/custom_components/blitzortung/const.py
+++ b/custom_components/blitzortung/const.py
@@ -1,12 +1,23 @@
 import datetime
+from typing import Any
+from dataclasses import dataclass
+
+from homeassistant.util.hass_dict import HassKey
+
 from .version import __version__
+
+
+@dataclass
+class BlitzortungConfig:
+    config: dict[str, Any]
+
 
 SW_VERSION = __version__
 
 PLATFORMS = ["sensor", "geo_location"]
 
 DOMAIN = "blitzortung"
-DATA_UNSUBSCRIBE = "unsubscribe"
+BLITZORTUNG_CONFIG: HassKey[BlitzortungConfig] = HassKey(DOMAIN)
 ATTR_LIGHTNING_AZIMUTH = "azimuth"
 ATTR_LIGHTNING_COUNTER = "counter"
 

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -30,7 +30,7 @@ SIGNAL_DELETE_ENTITY = "blitzortung_delete_entity_{0}"
 
 
 async def async_setup_entry(hass, config_entry: BlitzortungConfigEntry, async_add_entities):
-    coordinator = config_entry.runtimedata
+    coordinator = config_entry.runtime_data
     if not coordinator.max_tracked_lightnings:
         return
 

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.util.dt import utc_from_timestamp
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
+from . import BlitzortungConfigEntry
 from .const import ATTR_EXTERNAL_ID, ATTR_PUBLICATION_DATE, ATTRIBUTION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,8 +29,8 @@ DEFAULT_ICON = "mdi:flash"
 SIGNAL_DELETE_ENTITY = "blitzortung_delete_entity_{0}"
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+async def async_setup_entry(hass, config_entry: BlitzortungConfigEntry, async_add_entities):
+    coordinator = config_entry.runtimedata
     if not coordinator.max_tracked_lightnings:
         return
 

--- a/custom_components/blitzortung/sensor.py
+++ b/custom_components/blitzortung/sensor.py
@@ -11,6 +11,7 @@ from .const import (
     ATTR_LIGHTNING_COUNTER,
     ATTR_LON,
     ATTRIBUTION,
+    BLITZORTUNG_CONFIG,
     DOMAIN,
     SERVER_STATS,
     SW_VERSION,
@@ -38,7 +39,7 @@ async def async_setup_entry(hass, config_entry: BlitzortungConfigEntry, async_ad
 
     async_add_entities(sensors, False)
 
-    config = hass.data[DOMAIN].get("config") or {}
+    config = hass.data[BLITZORTUNG_CONFIG]
     if config.get(SERVER_STATS):
         server_stat_sensors = {}
 

--- a/custom_components/blitzortung/sensor.py
+++ b/custom_components/blitzortung/sensor.py
@@ -4,6 +4,7 @@ from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME, DEGREE, UnitOfLengt
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.helpers.device_registry import DeviceEntryType
 
+from . import BlitzortungConfigEntry
 from .const import (
     ATTR_LAT,
     ATTR_LIGHTNING_AZIMUTH,
@@ -23,10 +24,10 @@ ATTR_LIGHTNING_PROPERTY = "lightning_prop"
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(hass, config_entry: BlitzortungConfigEntry, async_add_entities):
     integration_name = config_entry.data[CONF_NAME]
 
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
 
     unique_prefix = config_entry.unique_id
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
     "name": "Blitzortung.org Lightning Detector",
-    "homeassistant": "2022.10.0"
+    "homeassistant": "2024.5.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
     "name": "Blitzortung.org Lightning Detector",
-    "homeassistant": "2024.5.0"
+    "homeassistant": "2024.6.0"
 }


### PR DESCRIPTION
Related to https://developers.home-assistant.io/blog/2024/04/30/store-runtime-data-inside-config-entry/ and https://developers.home-assistant.io/blog/2024/05/01/improved-hass-data-typing/

**Home Assistant 2024.6.0 required!**