### PR TITLE
Do not define `unique_id` for `geo_location` platform

### DIFF
--- a/custom_components/blitzortung/icons.json
+++ b/custom_components/blitzortung/icons.json
@@ -1,10 +1,5 @@
 {
   "entity": {
-    "geo_location": {
-      "lightning_strike": {
-        "default": "mdi:flash"
-      }
-    },
     "sensor": {
       "azimuth": {
         "default": "mdi:compass-outline"

--- a/custom_components/blitzortung/strings.json
+++ b/custom_components/blitzortung/strings.json
@@ -37,18 +37,6 @@
     }
   },
   "entity": {
-    "geo_location": {
-      "lightning_strike": {
-        "state_attributes": {
-          "external_id": {
-            "name": "External ID"
-          },
-          "publication_date": {
-            "name": "Publication date"
-          }
-        }
-      }
-    },
     "sensor": {
       "azimuth": {
         "state_attributes": {

--- a/custom_components/blitzortung/translations/en.json
+++ b/custom_components/blitzortung/translations/en.json
@@ -39,18 +39,6 @@
     }
   },
   "entity": {
-    "geo_location": {
-      "lightning_strike": {
-        "state_attributes": {
-          "external_id": {
-            "name": "External ID"
-          },
-          "publication_date": {
-            "name": "Publication date"
-          }
-        }
-      }
-    },
     "sensor": {
       "azimuth": {
         "state_attributes": {

--- a/custom_components/blitzortung/translations/pl.json
+++ b/custom_components/blitzortung/translations/pl.json
@@ -37,18 +37,6 @@
     }
   },
   "entity": {
-    "geo_location": {
-      "lightning_strike": {
-        "state_attributes": {
-          "external_id": {
-            "name": "Zewnętrzny identyfikator"
-          },
-          "publication_date": {
-            "name": "Data publikacji"
-          }
-        }
-      }
-    },
     "sensor": {
       "azimuth": {
         "state_attributes": {


### PR DESCRIPTION
HA dev team recommends not defining `unique_id` for the `geo_location` platform if there are a lot of events as is the case here.

Closes #134