### PR TITLE
Remove state class for entities using `unknown` state

### DIFF
--- a/custom_components/blitzortung/sensor.py
+++ b/custom_components/blitzortung/sensor.py
@@ -192,7 +192,6 @@ SENSORS: tuple[BlitzortungSensorEntityDescription, ...] = (
         translation_key=ATTR_LIGHTNING_AZIMUTH,
         has_entity_name=True,
         native_unit_of_measurement=DEGREE,
-        state_class=SensorStateClass.MEASUREMENT,
         entity_class=AzimuthSensor,
     ),
     BlitzortungSensorEntityDescription(
@@ -211,7 +210,6 @@ SENSORS: tuple[BlitzortungSensorEntityDescription, ...] = (
         has_entity_name=True,
         native_unit_of_measurement=UnitOfLength.KILOMETERS,
         device_class=SensorDeviceClass.DISTANCE,
-        state_class=SensorStateClass.MEASUREMENT,
         entity_class=DistanceSensor,
     ),
 )


### PR DESCRIPTION
HA since version 2024.10.0 displays warnings for entities for which `state_class` is set and their state changes to `unknown`. For this reason, it is better to completely abandon long-term statistics (remove `state_class`) for these entities:
- Lightning azimuth
- Lightning distance