### PR TITLE
Use prek instead of pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,16 +6,20 @@ repos:
         args:
           - --fix
       - id: ruff-format
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+  - repo: builtin
     hooks:
       - id: end-of-file-fixer
-      - id: mixed-line-ending
       - id: trailing-whitespace
+      - id: check-yaml
       - id: check-json
-      - id: pretty-format-json
-        args:
-          - --no-sort-keys
+      - id: check-toml
+      - id: mixed-line-ending
       - id: no-commit-to-branch
         args:
           - --branch=master
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: pretty-format-json
+        args:
+          - --no-sort-keys

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements-lint.txt
 homeassistant
-pre-commit==4.3.0
+prek==0.2.29


### PR DESCRIPTION
`prek` is faster than `pre-commit`, and the Home Assistant core repository uses it as its default pre-commit tool

Repo: https://github.com/j178/prek
