### PR TITLE
Reconcile recorder DB with in-memory cache; drain strike orphans

### DIFF
--- a/custom_components/blitzortung/__init__.py
+++ b/custom_components/blitzortung/__init__.py
@@ -319,6 +319,22 @@ class BlitzortungCoordinator:
             self.geohash_overlap,
         )
 
+        # geohash_overlap silently returns set() when the bounding box
+        # exceeds precision-1 tile coverage (~6700 km at mid-latitudes,
+        # less near the poles). Without subscriptions no strikes ever
+        # arrive, so make this audible rather than silent.
+        if self.latitude is not None and not self.geohash_overlap:
+            _LOGGER.warning(
+                "No geohash tiles for lat=%s lon=%s radius=%skm — the "
+                "bounding box exceeds geohash precision-1 coverage and "
+                "no MQTT subscriptions will be created. NO STRIKES WILL "
+                "ARRIVE until the radius is reduced (try below 4000 km "
+                "/ 2500 mi).",
+                self.latitude,
+                self.longitude,
+                self.radius,
+            )
+
         self.mqtt_client = MQTT(
             hass,
             "blitzortung.ha.sed.pl",
@@ -419,6 +435,12 @@ class BlitzortungCoordinator:
             self.radius,
             self.geohash_overlap,
         )
+        if not self.geohash_overlap:
+            _LOGGER.warning(
+                "After location/radius update, no geohash tiles overlap — "
+                "no MQTT subscriptions will be active until the radius is "
+                "reduced (try below 4000 km / 2500 mi)."
+            )
 
         # If connected, re-subscribe to the new geohash topics.
         if not self.is_connected:

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -157,9 +157,7 @@ async def _async_reconcile_strikes(
         for entry in hass.config_entries.async_entries(DOMAIN)
     )
     if others_loaded:
-        _LOGGER.debug(
-            "Skipping strike reconcile: another Blitzortung entry is loaded"
-        )
+        _LOGGER.debug("Skipping strike reconcile: another Blitzortung entry is loaded")
         return
 
     if RECORDER_DOMAIN not in hass.config.components:
@@ -205,9 +203,7 @@ async def _async_reconcile_strikes(
     # in the final log line. After this point, _cap_rebuild_to_capacity may
     # move overflow from rebuild → purge, which would otherwise hide the
     # "how many were actually outside the window" signal.
-    live_skipped = (
-        len(db_entity_ids) - len(rebuild_candidates) - len(purge_ids)
-    )
+    live_skipped = len(db_entity_ids) - len(rebuild_candidates) - len(purge_ids)
     outside_window = len(purge_ids)
     within_window = len(rebuild_candidates)
 
@@ -435,7 +431,8 @@ async def _async_batched_service_purge(
         except Exception:  # noqa: BLE001
             failed_chunks += 1
             _LOGGER.debug(
-                "Strike cleanup: chunk %d failed; continuing", chunk_idx,
+                "Strike cleanup: chunk %d failed; continuing",
+                chunk_idx,
                 exc_info=True,
             )
 
@@ -446,7 +443,10 @@ async def _async_batched_service_purge(
             _LOGGER.info(
                 "Strike cleanup: queued %d entries across %d chunks "
                 "(%.0fs elapsed, cursor=%d)",
-                total_queued, chunk_idx, elapsed, cursor,
+                total_queued,
+                chunk_idx,
+                elapsed,
+                cursor,
             )
 
         await asyncio.sleep(PURGE_CHUNK_DELAY)
@@ -456,12 +456,15 @@ async def _async_batched_service_purge(
         _LOGGER.warning(
             "Strike cleanup: queued %d entries in %.0fs (%d chunks failed; "
             "those entries will be retried by the next daily reconcile)",
-            total_queued, elapsed, failed_chunks,
+            total_queued,
+            elapsed,
+            failed_chunks,
         )
     else:
         _LOGGER.info(
             "Strike cleanup: drained all entries in %.0fs (%d queued)",
-            elapsed, total_queued,
+            elapsed,
+            total_queued,
         )
 
 
@@ -485,6 +488,7 @@ async def _async_enumerate_strike_chunk(
     live strike that arrived after cleanup started — those are left
     for normal eviction / the rebuild path to handle.
     """
+
     def _query() -> list[tuple[int, str]]:
         with session_scope(session=instance.get_session(), read_only=True) as session:
             rows = session.execute(
@@ -515,6 +519,7 @@ async def _async_enumerate_strike_chunk(
 
 async def _async_get_max_strike_metadata_id(instance: Any) -> int:
     """Return the highest metadata_id for strike entities, or 0 if none."""
+
     def _query() -> int:
         with session_scope(session=instance.get_session(), read_only=True) as session:
             row = session.execute(
@@ -649,11 +654,7 @@ class Strikes(list):
         gets removed.
         """
         k = self._key_fn(item)
-        if (
-            len(self) >= self._capacity
-            and self._keys
-            and k <= self._keys[0]
-        ):
+        if len(self) >= self._capacity and self._keys and k <= self._keys[0]:
             return None
         if k > self._max_key:
             self._max_key = k

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -1,5 +1,6 @@
 """Support for Blitzortung geo location events."""
 
+import asyncio
 import bisect
 import logging
 import time
@@ -39,13 +40,20 @@ RECORDER_DOMAIN = "recorder"
 RECONCILE_INTERVAL = timedelta(days=1)
 
 # When the DB has more orphan rows than this threshold, the rebuild path
-# becomes prohibitive (the categorise loop is O(N) on the main thread,
-# and a >2M-entity WHERE IN query into the recorder can hang the executor
-# for minutes). For such DBs we fall back to a glob purge that wipes
-# anything older than (time_window + a day's margin), preserving live
-# strikes for the next reconcile to handle but skipping the rebuild —
-# the integration self-heals once the DB shrinks under the threshold.
+# becomes prohibitive (the categorise loop is O(N) on the main thread, and
+# a >2M-entity WHERE IN query into the recorder can hang its executor for
+# minutes). For such DBs we drain via chunked recorder.purge_entities
+# service calls instead of fetching state for rebuild.
 RECONCILE_REBUILD_THRESHOLD = 10000
+
+# Service-based cleanup tuning. Each chunk is a small explicit entity_id
+# list passed to recorder.purge_entities — the recorder handles FK chains,
+# transactions, and schema portability correctly. Sleeping between chunks
+# lets the recorder's executor drain its queue and keeps the event loop
+# responsive. A 2M-strike cleanup at 1000/chunk and 1s/chunk takes ~30 min
+# in the background; HA stays usable throughout.
+PURGE_CHUNK_SIZE = 1000
+PURGE_CHUNK_DELAY = 1.0
 
 
 async def async_setup_entry(
@@ -162,14 +170,12 @@ async def _async_reconcile_strikes(
     )
 
     if len(db_entity_ids) > RECONCILE_REBUILD_THRESHOLD:
-        # Fast path. Skip rebuild and just bulk-purge anything older than the
-        # time window via a glob — the per-entity categorise loop would block
-        # the event loop for seconds at this volume, and a WHERE entity_id IN
-        # (...) with millions of values can hang the recorder executor for
-        # minutes. We lose map continuity across this restart, but the
-        # integration self-heals: once the DB drops under the threshold the
-        # next reconcile uses the full rebuild path.
-        await _async_fast_path_glob_purge(hass, manager, len(db_entity_ids))
+        # Skip rebuild and drain via chunked recorder.purge_entities calls.
+        # The rebuild path's categorise loop is O(N) on the main thread,
+        # and a single glob purge at multi-million scale has been observed
+        # to hang or drop the SQL connection. Chunked service calls keep
+        # each recorder task small and let the main loop stay responsive.
+        await _async_batched_service_purge(hass, manager, db_entity_ids)
         return
 
     start_time = dt_util.utcnow() - timedelta(seconds=manager._window_seconds)  # noqa: SLF001
@@ -326,41 +332,101 @@ async def _async_purge_entity_ids(hass: HomeAssistant, entity_ids: list[str]) ->
         _LOGGER.debug("Recorder purge_entities failed", exc_info=True)
 
 
-async def _async_fast_path_glob_purge(
+async def _async_batched_service_purge(
     hass: HomeAssistant,
     manager: "BlitzortungEventManager",
-    found_count: int,
+    db_entity_ids: list[str],
 ) -> None:
-    """Bulk-purge strike rows when the DB has too many entries to reconcile.
+    """Drain orphan strike rows via chunked recorder.purge_entities calls.
 
-    Uses recorder.purge_entities with the glob + keep_days. The recorder
-    processes the purge in its own executor; the main loop stays responsive.
-    keep_days is set to one day past the configured time window so any
-    truly-live strikes (whose last state was inside the window) survive.
+    Used when the DB has too many entries for the rebuild path. A single
+    glob purge on a multi-million-entity DB has been observed to:
+      * hang the recorder executor for very long stretches, since the
+        recorder's purge_entity_data enumerates the full states_meta
+        table in Python on every iteration; and
+      * raise operational errors (dropped SQL connection) on some
+        backends at this scale.
+
+    The fix is the same official service — recorder.purge_entities,
+    which handles FK chains, transactions, and schema portability
+    correctly — but called repeatedly with small explicit entity_id
+    chunks instead of one huge glob. Each chunk is a short, bounded
+    task in the recorder's executor; the asyncio.sleep between chunks
+    yields the event loop and lets the recorder drain its queue.
+
+    Preserves rows newer than the configured time_window + 1 day margin
+    via keep_days so any truly-live strikes survive. The integration
+    self-heals: once the DB drops under RECONCILE_REBUILD_THRESHOLD,
+    the next reconcile uses the rebuild path that restores map
+    continuity across restart.
     """
-    keep_days = max(1, manager._window_seconds // 86400 + 1)  # noqa: SLF001
+    window_seconds = manager._window_seconds  # noqa: SLF001
+    keep_days = max(1, window_seconds // 86400 + 1)
+    total = len(db_entity_ids)
+    chunks = (total + PURGE_CHUNK_SIZE - 1) // PURGE_CHUNK_SIZE
+
     _LOGGER.warning(
         "Strike reconcile: %d entries exceeds the rebuild threshold of %d. "
-        "Falling back to bulk glob purge (keep_days=%d) — the lightning map "
-        "will not show pre-restart strikes for this boot. The DB will be "
-        "trimmed in the background by the recorder; future restarts will use "
-        "the normal rebuild path once the count drops under the threshold.",
-        found_count,
+        "Draining via chunked recorder.purge_entities — %d chunks of %d, "
+        "%.1fs sleep between, keep_days=%d. Estimated runtime: ~%d min. "
+        "Map will not show pre-restart strikes during this boot.",
+        total,
         RECONCILE_REBUILD_THRESHOLD,
+        chunks,
+        PURGE_CHUNK_SIZE,
+        PURGE_CHUNK_DELAY,
         keep_days,
+        int(chunks * PURGE_CHUNK_DELAY / 60),
     )
-    try:
-        await hass.services.async_call(
-            RECORDER_DOMAIN,
-            "purge_entities",
-            {
-                "entity_globs": [f"{STRIKE_ENTITY_ID_PREFIX}*"],
-                "keep_days": keep_days,
-            },
-            blocking=False,
+
+    started = time.monotonic()
+    failed_chunks = 0
+    for offset in range(0, total, PURGE_CHUNK_SIZE):
+        chunk = db_entity_ids[offset : offset + PURGE_CHUNK_SIZE]
+        try:
+            await hass.services.async_call(
+                RECORDER_DOMAIN,
+                "purge_entities",
+                {"entity_id": chunk, "keep_days": keep_days},
+                blocking=False,
+            )
+        except Exception:  # noqa: BLE001
+            failed_chunks += 1
+            _LOGGER.debug(
+                "Strike cleanup: chunk at offset %d failed; continuing",
+                offset,
+                exc_info=True,
+            )
+
+        # Periodic progress log every ~100 chunks (~100K entries by default).
+        chunk_idx = offset // PURGE_CHUNK_SIZE
+        if chunk_idx > 0 and chunk_idx % 100 == 0:
+            elapsed = time.monotonic() - started
+            done = min(offset + PURGE_CHUNK_SIZE, total)
+            _LOGGER.info(
+                "Strike cleanup: queued %d/%d entries (%.0fs elapsed)",
+                done,
+                total,
+                elapsed,
+            )
+
+        await asyncio.sleep(PURGE_CHUNK_DELAY)
+
+    elapsed = time.monotonic() - started
+    if failed_chunks:
+        _LOGGER.warning(
+            "Strike cleanup: queued %d entries in %.0fs (%d chunks failed; "
+            "those entries will be retried by the next daily reconcile)",
+            total,
+            elapsed,
+            failed_chunks,
         )
-    except Exception:  # noqa: BLE001
-        _LOGGER.debug("Recorder fast-path glob purge failed", exc_info=True)
+    else:
+        _LOGGER.info(
+            "Strike cleanup: queued all %d entries in %.0fs",
+            total,
+            elapsed,
+        )
 
 
 class BlitzortungEvent(GeolocationEvent):

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 from homeassistant.util.dt import utc_from_timestamp
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
+from sqlalchemy import text
 
 from . import BlitzortungConfigEntry
 from .const import ATTR_EXTERNAL_ID, ATTR_PUBLICATION_DATE, ATTRIBUTION, DOMAIN
@@ -50,10 +51,21 @@ RECONCILE_REBUILD_THRESHOLD = 10000
 # list passed to recorder.purge_entities — the recorder handles FK chains,
 # transactions, and schema portability correctly. Sleeping between chunks
 # lets the recorder's executor drain its queue and keeps the event loop
-# responsive. A 2M-strike cleanup at 1000/chunk and 1s/chunk takes ~30 min
-# in the background; HA stays usable throughout.
-PURGE_CHUNK_SIZE = 1000
+# responsive.
+#
+# PURGE_CHUNK_SIZE is bounded by the recorder's MAX_EVENT_DATA_BYTES
+# (32 KB at HA 2026.5). The call_service event carries our entity_id
+# list as JSON; at ~67 bytes/entity_id, 350 lands around 24 KB with
+# comfortable margin. Going over the limit doesn't break the call
+# (the in-memory event still reaches the handler), but the recorder
+# logs a noisy warning per call and refuses to persist the event row.
+PURGE_CHUNK_SIZE = 350
 PURGE_CHUNK_DELAY = 1.0
+
+# Portable LIKE-with-ESCAPE pattern. '!' avoids the backslash-doubling
+# pain that MySQL and SQLite handle differently.
+_STRIKE_LIKE_PATTERN = "geo!_location.lightning!_strike!_%"
+_ESCAPE_CHAR = "!"
 
 
 async def async_setup_entry(
@@ -175,7 +187,9 @@ async def _async_reconcile_strikes(
         # and a single glob purge at multi-million scale has been observed
         # to hang or drop the SQL connection. Chunked service calls keep
         # each recorder task small and let the main loop stay responsive.
-        await _async_batched_service_purge(hass, manager, db_entity_ids)
+        # The cleanup function re-enumerates states_meta via cursor paging,
+        # so the count above (db_entity_ids) is only used for the log line.
+        await _async_batched_service_purge(hass, instance, manager, len(db_entity_ids))
         return
 
     start_time = dt_util.utcnow() - timedelta(seconds=manager._window_seconds)  # noqa: SLF001
@@ -334,8 +348,9 @@ async def _async_purge_entity_ids(hass: HomeAssistant, entity_ids: list[str]) ->
 
 async def _async_batched_service_purge(
     hass: HomeAssistant,
+    instance: Any,
     manager: "BlitzortungEventManager",
-    db_entity_ids: list[str],
+    initial_found_count: int,
 ) -> None:
     """Drain orphan strike rows via chunked recorder.purge_entities calls.
 
@@ -350,64 +365,75 @@ async def _async_batched_service_purge(
     The fix is the same official service — recorder.purge_entities,
     which handles FK chains, transactions, and schema portability
     correctly — but called repeatedly with small explicit entity_id
-    chunks instead of one huge glob. Each chunk is a short, bounded
-    task in the recorder's executor; the asyncio.sleep between chunks
-    yields the event loop and lets the recorder drain its queue.
+    chunks. Each chunk is a short, bounded task in the recorder's
+    executor; the asyncio.sleep between chunks yields the event loop
+    and lets the recorder drain its queue.
 
-    Preserves rows newer than the configured time_window + 1 day margin
-    via keep_days so any truly-live strikes survive. The integration
-    self-heals: once the DB drops under RECONCILE_REBUILD_THRESHOLD,
-    the next reconcile uses the rebuild path that restores map
-    continuity across restart.
+    Each iteration re-enumerates the next slice of states_meta via
+    cursor paging (metadata_id > last_seen). This adapts to concurrent
+    external cleanup (a user running the SQL script alongside us) and
+    terminates naturally when the table is empty — no stale snapshot
+    to grind through.
+
+    keep_days is derived from the integration's own time_window — no
+    extra margin. For sub-day windows, keep_days = 0, which purges
+    everything for the matched entity_ids regardless of age; the
+    rebuild path (under threshold) is where map continuity for live
+    strikes is preserved.
     """
     window_seconds = manager._window_seconds  # noqa: SLF001
-    keep_days = max(1, window_seconds // 86400 + 1)
-    total = len(db_entity_ids)
-    chunks = (total + PURGE_CHUNK_SIZE - 1) // PURGE_CHUNK_SIZE
+    keep_days = window_seconds // 86400
 
     _LOGGER.warning(
         "Strike reconcile: %d entries exceeds the rebuild threshold of %d. "
-        "Draining via chunked recorder.purge_entities — %d chunks of %d, "
-        "%.1fs sleep between, keep_days=%d. Estimated runtime: ~%d min. "
-        "Map will not show pre-restart strikes during this boot.",
-        total,
+        "Draining via chunked recorder.purge_entities (chunk=%d, "
+        "delay=%.1fs, keep_days=%d). The map will not show pre-restart "
+        "strikes during this boot.",
+        initial_found_count,
         RECONCILE_REBUILD_THRESHOLD,
-        chunks,
         PURGE_CHUNK_SIZE,
         PURGE_CHUNK_DELAY,
         keep_days,
-        int(chunks * PURGE_CHUNK_DELAY / 60),
     )
 
     started = time.monotonic()
+    cursor = 0
+    total_queued = 0
     failed_chunks = 0
-    for offset in range(0, total, PURGE_CHUNK_SIZE):
-        chunk = db_entity_ids[offset : offset + PURGE_CHUNK_SIZE]
+    chunk_idx = 0
+
+    while True:
+        chunk_data = await _async_enumerate_strike_chunk(
+            instance, cursor, PURGE_CHUNK_SIZE
+        )
+        if not chunk_data:
+            break
+
+        entity_ids = [eid for (_mid, eid) in chunk_data]
+        cursor = max(mid for (mid, _eid) in chunk_data)
+
         try:
             await hass.services.async_call(
                 RECORDER_DOMAIN,
                 "purge_entities",
-                {"entity_id": chunk, "keep_days": keep_days},
+                {"entity_id": entity_ids, "keep_days": keep_days},
                 blocking=False,
             )
         except Exception:  # noqa: BLE001
             failed_chunks += 1
             _LOGGER.debug(
-                "Strike cleanup: chunk at offset %d failed; continuing",
-                offset,
+                "Strike cleanup: chunk %d failed; continuing", chunk_idx,
                 exc_info=True,
             )
 
-        # Periodic progress log every ~100 chunks (~100K entries by default).
-        chunk_idx = offset // PURGE_CHUNK_SIZE
-        if chunk_idx > 0 and chunk_idx % 100 == 0:
+        total_queued += len(entity_ids)
+        chunk_idx += 1
+        if chunk_idx % 100 == 0:
             elapsed = time.monotonic() - started
-            done = min(offset + PURGE_CHUNK_SIZE, total)
             _LOGGER.info(
-                "Strike cleanup: queued %d/%d entries (%.0fs elapsed)",
-                done,
-                total,
-                elapsed,
+                "Strike cleanup: queued %d entries across %d chunks "
+                "(%.0fs elapsed, cursor=%d)",
+                total_queued, chunk_idx, elapsed, cursor,
             )
 
         await asyncio.sleep(PURGE_CHUNK_DELAY)
@@ -417,16 +443,51 @@ async def _async_batched_service_purge(
         _LOGGER.warning(
             "Strike cleanup: queued %d entries in %.0fs (%d chunks failed; "
             "those entries will be retried by the next daily reconcile)",
-            total,
-            elapsed,
-            failed_chunks,
+            total_queued, elapsed, failed_chunks,
         )
     else:
         _LOGGER.info(
-            "Strike cleanup: queued all %d entries in %.0fs",
-            total,
-            elapsed,
+            "Strike cleanup: drained all entries in %.0fs (%d queued)",
+            elapsed, total_queued,
         )
+
+
+async def _async_enumerate_strike_chunk(
+    instance: Any, after_metadata_id: int, limit: int
+) -> list[tuple[int, str]]:
+    """Return up to `limit` (metadata_id, entity_id) pairs above a cursor.
+
+    Cursor paging by metadata_id ensures forward progress: even if a
+    queued purge task hasn't actually deleted the row from states_meta
+    yet, we won't revisit it on the next iteration. The states_meta
+    table has an index on entity_id (ix_states_meta_entity_id) and
+    primary key on metadata_id, so the LIKE prefix + ORDER BY filter
+    is fast even on millions of rows.
+    """
+    def _query() -> list[tuple[int, str]]:
+        with session_scope(session=instance.get_session(), read_only=True) as session:
+            rows = session.execute(
+                text(
+                    # _ESCAPE_CHAR is a literal module constant, not user input.
+                    "SELECT metadata_id, entity_id FROM states_meta "  # noqa: S608
+                    f"WHERE entity_id LIKE :pat ESCAPE '{_ESCAPE_CHAR}' "
+                    "AND metadata_id > :after "
+                    "ORDER BY metadata_id "
+                    "LIMIT :limit"
+                ),
+                {
+                    "pat": _STRIKE_LIKE_PATTERN,
+                    "after": after_metadata_id,
+                    "limit": limit,
+                },
+            )
+            return [(row[0], row[1]) for row in rows]
+
+    try:
+        return await instance.async_add_executor_job(_query)
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Strike cleanup: cursor enumerate failed", exc_info=True)
+        return []
 
 
 class BlitzortungEvent(GeolocationEvent):

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -68,7 +68,18 @@ async def async_setup_entry(
     # Reconcile DB state with the empty in-memory cache: strikes still within
     # the time window come back to life on the map; strikes past their window
     # (orphaned by a previous HA reboot mid-storm) get precisely purged.
-    await _async_reconcile_strikes(hass, config_entry, manager)
+    #
+    # Run as a background task — on a production DB with tens of thousands of
+    # orphan rows, the bulk state-history fetch can easily take longer than
+    # HA's 60-second platform-setup deadline. Live strikes arriving from MQTT
+    # during the reconcile are safe: each one goes through Strikes.insort,
+    # which handles concurrent insertion correctly. The reconcile then skips
+    # whatever the live cache already contains.
+    config_entry.async_create_background_task(
+        hass,
+        _async_reconcile_strikes(hass, config_entry, manager),
+        name="blitzortung_reconcile_strikes_initial",
+    )
 
     # Daily backstop. Defensive against rare orphan accumulation during a
     # long-running HA process. Unregistered automatically on unload.
@@ -133,6 +144,14 @@ async def _async_reconcile_strikes(
     if not db_entity_ids:
         return
 
+    window_minutes = manager._window_seconds // 60  # noqa: SLF001
+    _LOGGER.info(
+        "Strike reconcile: found %d lightning_strike_* entries in recorder DB"
+        " (time window: %d min)",
+        len(db_entity_ids),
+        window_minutes,
+    )
+
     start_time = dt_util.utcnow() - timedelta(seconds=manager._window_seconds)  # noqa: SLF001
     states_dict = await _async_fetch_strike_states(
         hass, instance, db_entity_ids, start_time
@@ -142,9 +161,20 @@ async def _async_reconcile_strikes(
         db_entity_ids, states_dict, manager, start_time.timestamp()
     )
 
+    # Snapshot counts at the categorisation boundary so we can break them out
+    # in the final log line. After this point, _cap_rebuild_to_capacity may
+    # move overflow from rebuild → purge, which would otherwise hide the
+    # "how many were actually outside the window" signal.
+    live_skipped = (
+        len(db_entity_ids) - len(rebuild_candidates) - len(purge_ids)
+    )
+    outside_window = len(purge_ids)
+    within_window = len(rebuild_candidates)
+
     rebuild_candidates, purge_ids = _cap_rebuild_to_capacity(
         rebuild_candidates, purge_ids, manager
     )
+    overflow = within_window - len(rebuild_candidates)
 
     to_register: list[BlitzortungEvent] = []
     for event in rebuild_candidates:
@@ -162,10 +192,15 @@ async def _async_reconcile_strikes(
     if purge_ids:
         await _async_purge_entity_ids(hass, purge_ids)
 
-    _LOGGER.debug(
-        "Strike reconcile: rebuilt %d, purged %d",
+    _LOGGER.info(
+        "Strike reconcile complete: rebuilt %d (within window), "
+        "purged %d (outside window: %d, overflow past capacity: %d), "
+        "skipped %d already-live",
         len(to_register),
         len(purge_ids),
+        outside_window,
+        overflow,
+        live_skipped,
     )
 
 

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -38,6 +38,15 @@ STRIKE_ENTITY_ID_PREFIX = f"{GEO_LOCATION_PLATFORM}.lightning_strike_"
 RECORDER_DOMAIN = "recorder"
 RECONCILE_INTERVAL = timedelta(days=1)
 
+# When the DB has more orphan rows than this threshold, the rebuild path
+# becomes prohibitive (the categorise loop is O(N) on the main thread,
+# and a >2M-entity WHERE IN query into the recorder can hang the executor
+# for minutes). For such DBs we fall back to a glob purge that wipes
+# anything older than (time_window + a day's margin), preserving live
+# strikes for the next reconcile to handle but skipping the rebuild —
+# the integration self-heals once the DB shrinks under the threshold.
+RECONCILE_REBUILD_THRESHOLD = 10000
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -151,6 +160,17 @@ async def _async_reconcile_strikes(
         len(db_entity_ids),
         window_minutes,
     )
+
+    if len(db_entity_ids) > RECONCILE_REBUILD_THRESHOLD:
+        # Fast path. Skip rebuild and just bulk-purge anything older than the
+        # time window via a glob — the per-entity categorise loop would block
+        # the event loop for seconds at this volume, and a WHERE entity_id IN
+        # (...) with millions of values can hang the recorder executor for
+        # minutes. We lose map continuity across this restart, but the
+        # integration self-heals: once the DB drops under the threshold the
+        # next reconcile uses the full rebuild path.
+        await _async_fast_path_glob_purge(hass, manager, len(db_entity_ids))
+        return
 
     start_time = dt_util.utcnow() - timedelta(seconds=manager._window_seconds)  # noqa: SLF001
     states_dict = await _async_fetch_strike_states(
@@ -304,6 +324,43 @@ async def _async_purge_entity_ids(hass: HomeAssistant, entity_ids: list[str]) ->
         )
     except Exception:  # noqa: BLE001
         _LOGGER.debug("Recorder purge_entities failed", exc_info=True)
+
+
+async def _async_fast_path_glob_purge(
+    hass: HomeAssistant,
+    manager: "BlitzortungEventManager",
+    found_count: int,
+) -> None:
+    """Bulk-purge strike rows when the DB has too many entries to reconcile.
+
+    Uses recorder.purge_entities with the glob + keep_days. The recorder
+    processes the purge in its own executor; the main loop stays responsive.
+    keep_days is set to one day past the configured time window so any
+    truly-live strikes (whose last state was inside the window) survive.
+    """
+    keep_days = max(1, manager._window_seconds // 86400 + 1)  # noqa: SLF001
+    _LOGGER.warning(
+        "Strike reconcile: %d entries exceeds the rebuild threshold of %d. "
+        "Falling back to bulk glob purge (keep_days=%d) — the lightning map "
+        "will not show pre-restart strikes for this boot. The DB will be "
+        "trimmed in the background by the recorder; future restarts will use "
+        "the normal rebuild path once the count drops under the threshold.",
+        found_count,
+        RECONCILE_REBUILD_THRESHOLD,
+        keep_days,
+    )
+    try:
+        await hass.services.async_call(
+            RECORDER_DOMAIN,
+            "purge_entities",
+            {
+                "entity_globs": [f"{STRIKE_ENTITY_ID_PREFIX}*"],
+                "keep_days": keep_days,
+            },
+            blocking=False,
+        )
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Recorder fast-path glob purge failed", exc_info=True)
 
 
 class BlitzortungEvent(GeolocationEvent):

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -4,18 +4,26 @@ import bisect
 import logging
 import time
 import uuid
+from datetime import timedelta
 from typing import Any
 
 from homeassistant.components.geo_location import DOMAIN as GEO_LOCATION_PLATFORM
 from homeassistant.components.geo_location import GeolocationEvent
-from homeassistant.const import UnitOfLength
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.components.recorder import get_instance as recorder_get_instance
+from homeassistant.components.recorder.db_schema import StatesMeta
+from homeassistant.components.recorder.history import get_significant_states
+from homeassistant.components.recorder.util import session_scope
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, UnitOfLength
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import dt as dt_util
 from homeassistant.util.dt import utc_from_timestamp
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
@@ -25,6 +33,10 @@ from .const import ATTR_EXTERNAL_ID, ATTR_PUBLICATION_DATE, ATTRIBUTION, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 SIGNAL_DELETE_ENTITY = "blitzortung_delete_entity_{0}"
+
+STRIKE_ENTITY_ID_PREFIX = f"{GEO_LOCATION_PLATFORM}.lightning_strike_"
+RECORDER_DOMAIN = "recorder"
+RECONCILE_INTERVAL = timedelta(days=1)
 
 
 async def async_setup_entry(
@@ -53,8 +65,210 @@ async def async_setup_entry(
         coordinator.time_window_seconds,
     )
 
+    # Reconcile DB state with the empty in-memory cache: strikes still within
+    # the time window come back to life on the map; strikes past their window
+    # (orphaned by a previous HA reboot mid-storm) get precisely purged.
+    await _async_reconcile_strikes(hass, config_entry, manager)
+
+    # Daily backstop. Defensive against rare orphan accumulation during a
+    # long-running HA process. Unregistered automatically on unload.
+    async def _periodic_reconcile(_now: Any) -> None:
+        await _async_reconcile_strikes(hass, config_entry, manager)
+
+    config_entry.async_on_unload(
+        async_track_time_interval(hass, _periodic_reconcile, RECONCILE_INTERVAL)
+    )
+
     coordinator.register_lightning_receiver(manager.lightning_cb)
     coordinator.register_on_tick(manager.tick)
+
+
+async def _async_reconcile_strikes(
+    hass: HomeAssistant,
+    config_entry: BlitzortungConfigEntry,
+    manager: "BlitzortungEventManager",
+) -> None:
+    """Reconcile recorder-persisted strikes with the in-memory cache.
+
+    The integration's strike entities are short-lived (max 24 h) but the
+    recorder DB outlives them: rows for a strike active when HA stopped
+    sit in the DB until normal retention purges them (often 6 months on
+    user configs). With a national-scale cache (5000+ strikes), that's
+    hundreds of thousands of orphan rows across reboots.
+
+    Strategy:
+
+    1. Enumerate every ``lightning_strike_*`` entity_id in the DB.
+    2. Bulk-fetch their last state within the configured time window.
+    3. For entities with state inside the window: reconstruct them as live
+       events, insert into the in-memory cache up to capacity (newest first),
+       register with HA. Normal ``tick()`` evicts them as time runs out,
+       producing proper removal records — no special-case purge needed.
+    4. For entities outside the window (orphans), and any rebuild overflow,
+       call recorder.purge_entities with the precise entity_id list.
+
+    Skipped entirely when a sibling Blitzortung config entry is already
+    loaded: strike entity_ids carry only a UUID, so we can't tell our
+    orphans from a sibling's live strikes.
+    """
+    others_loaded = any(
+        entry.entry_id != config_entry.entry_id
+        and entry.state == ConfigEntryState.LOADED
+        for entry in hass.config_entries.async_entries(DOMAIN)
+    )
+    if others_loaded:
+        _LOGGER.debug(
+            "Skipping strike reconcile: another Blitzortung entry is loaded"
+        )
+        return
+
+    if RECORDER_DOMAIN not in hass.config.components:
+        return
+
+    instance = recorder_get_instance(hass)
+    if instance is None:
+        return
+
+    db_entity_ids = await _async_enumerate_strike_entity_ids(instance)
+    if not db_entity_ids:
+        return
+
+    start_time = dt_util.utcnow() - timedelta(seconds=manager._window_seconds)  # noqa: SLF001
+    states_dict = await _async_fetch_strike_states(
+        hass, instance, db_entity_ids, start_time
+    )
+
+    rebuild_candidates, purge_ids = _categorise_strikes(
+        db_entity_ids, states_dict, manager, start_time.timestamp()
+    )
+
+    rebuild_candidates, purge_ids = _cap_rebuild_to_capacity(
+        rebuild_candidates, purge_ids, manager
+    )
+
+    to_register: list[BlitzortungEvent] = []
+    for event in rebuild_candidates:
+        # insort returns None only if at-capacity-and-older-than-oldest,
+        # which can't happen here (we just cleared against capacity), but
+        # handle defensively.
+        if manager._strikes.insort(event) is None:  # noqa: SLF001
+            purge_ids.append(event.entity_id)
+            continue
+        to_register.append(event)
+
+    if to_register:
+        manager._async_add_entities(to_register)  # noqa: SLF001
+
+    if purge_ids:
+        await _async_purge_entity_ids(hass, purge_ids)
+
+    _LOGGER.debug(
+        "Strike reconcile: rebuilt %d, purged %d",
+        len(to_register),
+        len(purge_ids),
+    )
+
+
+async def _async_enumerate_strike_entity_ids(instance: Any) -> list[str]:
+    """Return all lightning_strike_* entity_ids known to the recorder.
+
+    Uses the same StatesMeta query the recorder runs internally for
+    purge_entities — there is no public glob-enumeration API.
+    """
+
+    def _query() -> list[str]:
+        with session_scope(session=instance.get_session(), read_only=True) as session:
+            return [
+                eid
+                for (eid,) in session.query(StatesMeta.entity_id)
+                .filter(StatesMeta.entity_id.like(f"{STRIKE_ENTITY_ID_PREFIX}%"))
+                .all()
+            ]
+
+    try:
+        return await instance.async_add_executor_job(_query)
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Failed to enumerate strike entity_ids", exc_info=True)
+        return []
+
+
+async def _async_fetch_strike_states(
+    hass: HomeAssistant,
+    instance: Any,
+    entity_ids: list[str],
+    start_time: Any,
+) -> dict[str, list[State]]:
+    """Bulk-fetch the last state inside the time window for each entity_id."""
+    try:
+        return await instance.async_add_executor_job(
+            get_significant_states,
+            hass,
+            start_time,
+            None,  # end_time
+            entity_ids,
+            None,  # filters
+            False,  # include_start_time_state — only changes within window
+        )
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Failed to fetch strike state history", exc_info=True)
+        return {}
+
+
+def _categorise_strikes(
+    db_entity_ids: list[str],
+    states_dict: dict[str, list[State]],
+    manager: "BlitzortungEventManager",
+    start_ts: float,
+) -> tuple[list["BlitzortungEvent"], list[str]]:
+    """Split DB entity_ids into rebuild candidates and purge-bound orphans."""
+    live_entity_ids = {ev.entity_id for ev in manager._strikes}  # noqa: SLF001
+    rebuild_candidates: list[BlitzortungEvent] = []
+    purge_ids: list[str] = []
+
+    for entity_id in db_entity_ids:
+        if entity_id in live_entity_ids:
+            continue
+        states = states_dict.get(entity_id, [])
+        if not states:
+            purge_ids.append(entity_id)
+            continue
+        event = BlitzortungEvent.from_recorder_state(states[-1], manager._unit)  # noqa: SLF001
+        if event is None or event._publication_date < start_ts:  # noqa: SLF001
+            purge_ids.append(entity_id)
+            continue
+        rebuild_candidates.append(event)
+
+    return rebuild_candidates, purge_ids
+
+
+def _cap_rebuild_to_capacity(
+    rebuild_candidates: list["BlitzortungEvent"],
+    purge_ids: list[str],
+    manager: "BlitzortungEventManager",
+) -> tuple[list["BlitzortungEvent"], list[str]]:
+    """Trim rebuild list to remaining cache capacity; overflow joins purge."""
+    remaining = manager._strikes._capacity - len(manager._strikes)  # noqa: SLF001
+    if remaining <= 0:
+        purge_ids.extend(e.entity_id for e in rebuild_candidates)
+        return [], purge_ids
+    if len(rebuild_candidates) > remaining:
+        rebuild_candidates.sort(key=lambda e: e._publication_date, reverse=True)  # noqa: SLF001
+        purge_ids.extend(e.entity_id for e in rebuild_candidates[remaining:])
+        rebuild_candidates = rebuild_candidates[:remaining]
+    return rebuild_candidates, purge_ids
+
+
+async def _async_purge_entity_ids(hass: HomeAssistant, entity_ids: list[str]) -> None:
+    """Call recorder.purge_entities with an explicit entity_id list."""
+    try:
+        await hass.services.async_call(
+            RECORDER_DOMAIN,
+            "purge_entities",
+            {"entity_id": entity_ids},
+            blocking=False,
+        )
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Recorder purge_entities failed", exc_info=True)
 
 
 class BlitzortungEvent(GeolocationEvent):
@@ -68,22 +282,29 @@ class BlitzortungEvent(GeolocationEvent):
 
     def __init__(
         self,
-        distance: int,
+        distance: float,
         latitude: float,
         longitude: float,
         unit: str,
         time: int,
         status: int,
         region: int,
+        strike_id: str | None = None,
     ) -> None:
-        """Initialize entity with data provided."""
+        """Initialize entity with data provided.
+
+        ``strike_id`` is normally generated fresh per strike; the optional
+        argument exists so the reconcile path can reconstruct an event with
+        the original entity_id after an HA restart, preserving recorder
+        history continuity.
+        """
         self._time = time
         self._status = status
         self._region = region
         self._publication_date = time / 1e9
         self._remove_signal_delete = None
-        self._strike_id = str(uuid.uuid4()).replace("-", "")
-        self.entity_id = f"geo_location.lightning_strike_{self._strike_id}"
+        self._strike_id = strike_id or str(uuid.uuid4()).replace("-", "")
+        self.entity_id = f"{STRIKE_ENTITY_ID_PREFIX}{self._strike_id}"
         self._attr_distance = distance
         self._attr_latitude = latitude
         self._attr_longitude = longitude
@@ -92,6 +313,40 @@ class BlitzortungEvent(GeolocationEvent):
             ATTR_PUBLICATION_DATE: utc_from_timestamp(self._publication_date),
         }
         self._attr_unit_of_measurement = unit
+
+    @classmethod
+    def from_recorder_state(cls, state: State, unit: str) -> "BlitzortungEvent | None":
+        """Reconstruct a strike from a recorder-persisted state row.
+
+        Returns None if the row's shape is unexpected (corrupt attributes,
+        missing fields). Defensive — recorder schema changes or partial
+        writes shouldn't break setup.
+        """
+        try:
+            strike_id = state.attributes[ATTR_EXTERNAL_ID]
+            pub_date_raw = state.attributes[ATTR_PUBLICATION_DATE]
+            if isinstance(pub_date_raw, str):
+                pub_date = dt_util.parse_datetime(pub_date_raw)
+            else:
+                pub_date = pub_date_raw
+            if pub_date is None:
+                return None
+            distance = float(state.state)
+            latitude = float(state.attributes[ATTR_LATITUDE])
+            longitude = float(state.attributes[ATTR_LONGITUDE])
+        except (KeyError, ValueError, TypeError):
+            return None
+        # status/region aren't preserved in state attributes; default to 0.
+        return cls(
+            distance=distance,
+            latitude=latitude,
+            longitude=longitude,
+            unit=unit,
+            time=int(pub_date.timestamp() * 1e9),
+            status=0,
+            region=0,
+            strike_id=strike_id,
+        )
 
     @callback
     def _delete_callback(self) -> None:
@@ -119,9 +374,24 @@ class Strikes(list):
         self._capacity = capacity
         super().__init__()
 
-    def insort(self, item: BlitzortungEvent) -> tuple[BlitzortungEvent]:
-        """Insert item into the list, keeping it sorted by key."""
+    def insort(self, item: BlitzortungEvent) -> tuple[BlitzortungEvent, ...] | None:
+        """Insert item into the list, keeping it sorted by key.
+
+        Returns the tuple of evicted items (possibly empty), or None if the item
+        was rejected because it's older than every retained strike and the cache
+        is already at capacity. Rejection avoids a race in which the caller
+        registers the new entity with HA and then immediately fires the
+        eviction signal — before the entity's delete-listener has been
+        attached in async_added_to_hass — leaving a ghost entity that never
+        gets removed.
+        """
         k = self._key_fn(item)
+        if (
+            len(self) >= self._capacity
+            and self._keys
+            and k <= self._keys[0]
+        ):
+            return None
         if k > self._max_key:
             self._max_key = k
             self._keys.append(k)
@@ -135,7 +405,7 @@ class Strikes(list):
             del self._keys[0:n]
             to_delete = self[0:n]
             self[0:n] = []
-            return to_delete
+            return tuple(to_delete)
         return ()
 
     def cleanup(self, k: float) -> tuple[BlitzortungEvent]:
@@ -187,6 +457,12 @@ class BlitzortungEventManager:
             lightning["region"],
         )
         to_delete = self._strikes.insort(event)
+        if to_delete is None:
+            _LOGGER.debug(
+                "Dropping late strike at %s (older than oldest tracked)",
+                event._publication_date,  # noqa: SLF001
+            )
+            return
         self._async_add_entities([event])
         if to_delete:
             self._remove_events(to_delete)

--- a/custom_components/blitzortung/geo_location.py
+++ b/custom_components/blitzortung/geo_location.py
@@ -375,6 +375,13 @@ async def _async_batched_service_purge(
     terminates naturally when the table is empty — no stale snapshot
     to grind through.
 
+    Bounded by max(metadata_id) at start time. New strikes arriving
+    from MQTT during the drain get higher metadata_ids than the upper
+    bound and are deliberately skipped — otherwise the cursor loop
+    would chase its own tail forever, purging live strikes as fast as
+    MQTT delivers them. Without this bound, an active storm would keep
+    the integration's map permanently empty.
+
     keep_days is derived from the integration's own time_window — no
     extra margin. For sub-day windows, keep_days = 0, which purges
     everything for the matched entity_ids regardless of age; the
@@ -384,16 +391,22 @@ async def _async_batched_service_purge(
     window_seconds = manager._window_seconds  # noqa: SLF001
     keep_days = window_seconds // 86400
 
+    upper_bound = await _async_get_max_strike_metadata_id(instance)
+    if not upper_bound:
+        _LOGGER.info("Strike cleanup: nothing in states_meta to drain")
+        return
+
     _LOGGER.warning(
         "Strike reconcile: %d entries exceeds the rebuild threshold of %d. "
         "Draining via chunked recorder.purge_entities (chunk=%d, "
-        "delay=%.1fs, keep_days=%d). The map will not show pre-restart "
-        "strikes during this boot.",
+        "delay=%.1fs, keep_days=%d, upper_bound=metadata_id<=%d). The map "
+        "will not show pre-restart strikes during this boot.",
         initial_found_count,
         RECONCILE_REBUILD_THRESHOLD,
         PURGE_CHUNK_SIZE,
         PURGE_CHUNK_DELAY,
         keep_days,
+        upper_bound,
     )
 
     started = time.monotonic()
@@ -404,7 +417,7 @@ async def _async_batched_service_purge(
 
     while True:
         chunk_data = await _async_enumerate_strike_chunk(
-            instance, cursor, PURGE_CHUNK_SIZE
+            instance, cursor, PURGE_CHUNK_SIZE, upper_bound
         )
         if not chunk_data:
             break
@@ -453,7 +466,10 @@ async def _async_batched_service_purge(
 
 
 async def _async_enumerate_strike_chunk(
-    instance: Any, after_metadata_id: int, limit: int
+    instance: Any,
+    after_metadata_id: int,
+    limit: int,
+    upper_bound: int,
 ) -> list[tuple[int, str]]:
     """Return up to `limit` (metadata_id, entity_id) pairs above a cursor.
 
@@ -463,6 +479,11 @@ async def _async_enumerate_strike_chunk(
     table has an index on entity_id (ix_states_meta_entity_id) and
     primary key on metadata_id, so the LIKE prefix + ORDER BY filter
     is fast even on millions of rows.
+
+    upper_bound (inclusive) caps the cursor walk at the snapshot taken
+    when cleanup began. Anything with metadata_id > upper_bound is a
+    live strike that arrived after cleanup started — those are left
+    for normal eviction / the rebuild path to handle.
     """
     def _query() -> list[tuple[int, str]]:
         with session_scope(session=instance.get_session(), read_only=True) as session:
@@ -472,12 +493,14 @@ async def _async_enumerate_strike_chunk(
                     "SELECT metadata_id, entity_id FROM states_meta "  # noqa: S608
                     f"WHERE entity_id LIKE :pat ESCAPE '{_ESCAPE_CHAR}' "
                     "AND metadata_id > :after "
+                    "AND metadata_id <= :upper "
                     "ORDER BY metadata_id "
                     "LIMIT :limit"
                 ),
                 {
                     "pat": _STRIKE_LIKE_PATTERN,
                     "after": after_metadata_id,
+                    "upper": upper_bound,
                     "limit": limit,
                 },
             )
@@ -488,6 +511,27 @@ async def _async_enumerate_strike_chunk(
     except Exception:  # noqa: BLE001
         _LOGGER.debug("Strike cleanup: cursor enumerate failed", exc_info=True)
         return []
+
+
+async def _async_get_max_strike_metadata_id(instance: Any) -> int:
+    """Return the highest metadata_id for strike entities, or 0 if none."""
+    def _query() -> int:
+        with session_scope(session=instance.get_session(), read_only=True) as session:
+            row = session.execute(
+                text(
+                    # _ESCAPE_CHAR is a literal module constant, not user input.
+                    "SELECT MAX(metadata_id) FROM states_meta "  # noqa: S608
+                    f"WHERE entity_id LIKE :pat ESCAPE '{_ESCAPE_CHAR}'"
+                ),
+                {"pat": _STRIKE_LIKE_PATTERN},
+            ).fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
+
+    try:
+        return await instance.async_add_executor_job(_query)
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("Strike cleanup: max metadata_id query failed", exc_info=True)
+        return 0
 
 
 class BlitzortungEvent(GeolocationEvent):

--- a/custom_components/blitzortung/manifest.json
+++ b/custom_components/blitzortung/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "blitzortung",
   "name": "Blitzortung",
-  "after_dependencies": [],
+  "after_dependencies": ["recorder"],
   "codeowners": [
     "@mrk-its"
   ],

--- a/tests/test_geo_location.py
+++ b/tests/test_geo_location.py
@@ -557,51 +557,67 @@ async def test_reconcile_fast_path_when_db_exceeds_threshold(
     fetch_mock.assert_not_called()
     # Service-based batched purge was invoked with the full ID list.
     purge_mock.assert_called_once()
-    hass_arg, manager_arg, ids_arg = purge_mock.call_args.args
+    hass_arg, instance_arg, manager_arg, found_count = purge_mock.call_args.args
     assert hass_arg is hass
     assert manager_arg is manager
-    assert ids_arg == huge_id_list
+    assert instance_arg is not None
+    assert found_count == len(huge_id_list)
 
 
 @pytest.mark.asyncio
-async def test_batched_service_purge_chunks_calls_and_sleeps(
+async def test_batched_service_purge_drains_via_cursor_until_empty(
     hass: HomeAssistant,
 ) -> None:
-    """Drains the entity-id list via small purge_entities chunks with sleeps."""
+    """Cleanup loops cursor-paged enumerations until the table is empty."""
     manager = _make_manager(window_seconds=7200)
+    instance = MagicMock()
 
-    # 2.5 chunks worth of entity IDs.
+    # 2.5 chunks worth of strike entities; cursor enumerator returns slices.
     total = int(PURGE_CHUNK_SIZE * 2.5)
-    ids = [f"{STRIKE_ENTITY_ID_PREFIX}{i:08x}" for i in range(total)]
+    all_rows = [
+        (i + 1, f"{STRIKE_ENTITY_ID_PREFIX}{i:08x}") for i in range(total)
+    ]
 
-    purge_mock = AsyncMock()
+    call_log: list[list[str]] = []
+
+    async def fake_enumerate(_inst: object, after: int, limit: int) -> list:
+        # Return rows with metadata_id > after, up to limit.
+        return [r for r in all_rows if r[0] > after][:limit]
+
+    purge_mock = AsyncMock(
+        side_effect=lambda call: call_log.append(list(call.data["entity_id"])),
+    )
     hass.services.async_register("recorder", "purge_entities", purge_mock)
     sleep_mock = AsyncMock()
 
-    with patch(
-        "custom_components.blitzortung.geo_location.asyncio.sleep",
-        new=sleep_mock,
+    with (
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_enumerate_strike_chunk",
+            new=fake_enumerate,
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location.asyncio.sleep",
+            new=sleep_mock,
+        ),
     ):
-        await _async_batched_service_purge(hass, manager, ids)
+        await _async_batched_service_purge(hass, instance, manager, total)
 
-    # 3 chunks (1000, 1000, 500). Each → one service call + one sleep.
+    # 3 chunks (350, 350, 175). Then a 4th enumerate returns empty → terminate.
     assert purge_mock.call_count == 3
     assert sleep_mock.call_count == 3
-
-    # Every chunk passes entity_id (not entity_globs) and a keep_days >= 1.
-    chunk_sizes = []
-    for call in purge_mock.call_args_list:
-        data = call.args[0].data
-        assert "entity_id" in data
-        assert "entity_globs" not in data
-        assert data["keep_days"] >= 1
-        chunk_sizes.append(len(data["entity_id"]))
-
+    chunk_sizes = [len(ids) for ids in call_log]
     assert chunk_sizes == [
         PURGE_CHUNK_SIZE,
         PURGE_CHUNK_SIZE,
         total - 2 * PURGE_CHUNK_SIZE,
     ]
+    # keep_days is derived from time_window (7200s = 0 days, since < 1 day).
+    for call in purge_mock.call_args_list:
+        data = call.args[0].data
+        assert "entity_id" in data
+        assert "entity_globs" not in data
+        assert data["keep_days"] == 0
 
 
 @pytest.mark.asyncio
@@ -610,11 +626,19 @@ async def test_batched_service_purge_continues_after_chunk_failure(
 ) -> None:
     """One failing chunk must not abort the whole drain."""
     manager = _make_manager(window_seconds=7200)
-    ids = [f"{STRIKE_ENTITY_ID_PREFIX}{i:08x}" for i in range(PURGE_CHUNK_SIZE * 3)]
+    instance = MagicMock()
+
+    total = PURGE_CHUNK_SIZE * 3
+    all_rows = [
+        (i + 1, f"{STRIKE_ENTITY_ID_PREFIX}{i:08x}") for i in range(total)
+    ]
+
+    async def fake_enumerate(_inst: object, after: int, limit: int) -> list:
+        return [r for r in all_rows if r[0] > after][:limit]
 
     call_n = {"i": 0}
 
-    async def flaky_purge(call: object) -> None:
+    async def flaky_purge(_call: object) -> None:
         call_n["i"] += 1
         if call_n["i"] == 2:
             raise RuntimeError("transient recorder error")
@@ -622,15 +646,69 @@ async def test_batched_service_purge_continues_after_chunk_failure(
     hass.services.async_register("recorder", "purge_entities", flaky_purge)
     sleep_mock = AsyncMock()
 
-    with patch(
-        "custom_components.blitzortung.geo_location.asyncio.sleep",
-        new=sleep_mock,
+    with (
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_enumerate_strike_chunk",
+            new=fake_enumerate,
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location.asyncio.sleep",
+            new=sleep_mock,
+        ),
     ):
-        # Must not raise.
-        await _async_batched_service_purge(hass, manager, ids)
+        await _async_batched_service_purge(hass, instance, manager, total)
 
-    # All 3 chunks were attempted; the failure in chunk 2 didn't abort the loop.
+    # All 3 chunks attempted; the failure in chunk 2 didn't abort the loop.
     assert call_n["i"] == 3
+
+
+@pytest.mark.asyncio
+async def test_batched_service_purge_uses_window_for_keep_days(
+    hass: HomeAssistant,
+) -> None:
+    """keep_days = window_seconds // 86400, no 24h margin added."""
+    instance = MagicMock()
+
+    # Single chunk only — set up empty enumeration after the first slice.
+    async def fake_enumerate_once(_inst: object, after: int, limit: int) -> list:
+        if after == 0:
+            return [(1, f"{STRIKE_ENTITY_ID_PREFIX}aa")]
+        return []
+
+    purge_mock = AsyncMock()
+    hass.services.async_register("recorder", "purge_entities", purge_mock)
+
+    with (
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_enumerate_strike_chunk",
+            new=fake_enumerate_once,
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+    ):
+        # window = 25h → keep_days = 25*3600 // 86400 = 1
+        await _async_batched_service_purge(
+            hass, instance, _make_manager(window_seconds=25 * 3600), 1
+        )
+        assert purge_mock.call_args.args[0].data["keep_days"] == 1
+        purge_mock.reset_mock()
+
+        # window = 2d → keep_days = 2
+        await _async_batched_service_purge(
+            hass, instance, _make_manager(window_seconds=2 * 86400), 1
+        )
+        assert purge_mock.call_args.args[0].data["keep_days"] == 2
+        purge_mock.reset_mock()
+
+        # window = 2h → keep_days = 0 (sub-day, no preservation)
+        await _async_batched_service_purge(
+            hass, instance, _make_manager(window_seconds=2 * 3600), 1
+        )
+        assert purge_mock.call_args.args[0].data["keep_days"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_geo_location.py
+++ b/tests/test_geo_location.py
@@ -31,12 +31,14 @@ from custom_components.blitzortung.const import (
     DOMAIN,
 )
 from custom_components.blitzortung.geo_location import (
+    PURGE_CHUNK_SIZE,
     RECONCILE_INTERVAL,
     RECONCILE_REBUILD_THRESHOLD,
     STRIKE_ENTITY_ID_PREFIX,
     BlitzortungEvent,
     BlitzortungEventManager,
     Strikes,
+    _async_batched_service_purge,
     _async_reconcile_strikes,
     _cap_rebuild_to_capacity,
     _categorise_strikes,
@@ -509,12 +511,12 @@ async def test_reconcile_rebuilds_within_window_strikes(
 async def test_reconcile_fast_path_when_db_exceeds_threshold(
     hass: HomeAssistant,
 ) -> None:
-    """Huge DBs must skip the rebuild path and use a glob purge instead.
+    """Huge DBs must skip rebuild and drain via chunked purge_entities calls.
 
-    The categorise loop is O(N) on the main thread, and a multi-million-entry
-    WHERE IN query into the recorder can hang its executor. The fast path
-    keeps the integration responsive at the cost of one boot without map
-    continuity.
+    The rebuild path's categorise loop is O(N) on the main thread and the
+    bulk state fetch can hang the recorder executor at scale. Chunked
+    service calls keep each recorder task small and let the main loop
+    stay responsive while the orphans drain in the background.
     """
     entry = _make_entry()
     entry.add_to_hass(hass)
@@ -525,9 +527,8 @@ async def test_reconcile_fast_path_when_db_exceeds_threshold(
         for i in range(RECONCILE_REBUILD_THRESHOLD + 1)
     ]
 
-    purge_mock = AsyncMock()
-    hass.services.async_register("recorder", "purge_entities", purge_mock)
     fetch_mock = AsyncMock(return_value={})
+    purge_mock = AsyncMock()
 
     with (
         patch.object(hass.config, "components", {*hass.config.components, "recorder"}),
@@ -544,16 +545,92 @@ async def test_reconcile_fast_path_when_db_exceeds_threshold(
             "custom_components.blitzortung.geo_location._async_fetch_strike_states",
             new=fetch_mock,
         ),
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_batched_service_purge",
+            new=purge_mock,
+        ),
     ):
         await _async_reconcile_strikes(hass, entry, manager)
 
     # Bulk state fetch (the heavy O(N) categorise input) was NOT called.
     fetch_mock.assert_not_called()
-    # Purge fell back to the glob path, not an explicit per-entity list.
+    # Service-based batched purge was invoked with the full ID list.
     purge_mock.assert_called_once()
-    call_data = purge_mock.call_args.args[0].data
-    assert call_data["entity_globs"] == [f"{STRIKE_ENTITY_ID_PREFIX}*"]
-    assert call_data["keep_days"] >= 1
+    hass_arg, manager_arg, ids_arg = purge_mock.call_args.args
+    assert hass_arg is hass
+    assert manager_arg is manager
+    assert ids_arg == huge_id_list
+
+
+@pytest.mark.asyncio
+async def test_batched_service_purge_chunks_calls_and_sleeps(
+    hass: HomeAssistant,
+) -> None:
+    """Drains the entity-id list via small purge_entities chunks with sleeps."""
+    manager = _make_manager(window_seconds=7200)
+
+    # 2.5 chunks worth of entity IDs.
+    total = int(PURGE_CHUNK_SIZE * 2.5)
+    ids = [f"{STRIKE_ENTITY_ID_PREFIX}{i:08x}" for i in range(total)]
+
+    purge_mock = AsyncMock()
+    hass.services.async_register("recorder", "purge_entities", purge_mock)
+    sleep_mock = AsyncMock()
+
+    with patch(
+        "custom_components.blitzortung.geo_location.asyncio.sleep",
+        new=sleep_mock,
+    ):
+        await _async_batched_service_purge(hass, manager, ids)
+
+    # 3 chunks (1000, 1000, 500). Each → one service call + one sleep.
+    assert purge_mock.call_count == 3
+    assert sleep_mock.call_count == 3
+
+    # Every chunk passes entity_id (not entity_globs) and a keep_days >= 1.
+    chunk_sizes = []
+    for call in purge_mock.call_args_list:
+        data = call.args[0].data
+        assert "entity_id" in data
+        assert "entity_globs" not in data
+        assert data["keep_days"] >= 1
+        chunk_sizes.append(len(data["entity_id"]))
+
+    assert chunk_sizes == [
+        PURGE_CHUNK_SIZE,
+        PURGE_CHUNK_SIZE,
+        total - 2 * PURGE_CHUNK_SIZE,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_batched_service_purge_continues_after_chunk_failure(
+    hass: HomeAssistant,
+) -> None:
+    """One failing chunk must not abort the whole drain."""
+    manager = _make_manager(window_seconds=7200)
+    ids = [f"{STRIKE_ENTITY_ID_PREFIX}{i:08x}" for i in range(PURGE_CHUNK_SIZE * 3)]
+
+    call_n = {"i": 0}
+
+    async def flaky_purge(call: object) -> None:
+        call_n["i"] += 1
+        if call_n["i"] == 2:
+            raise RuntimeError("transient recorder error")
+
+    hass.services.async_register("recorder", "purge_entities", flaky_purge)
+    sleep_mock = AsyncMock()
+
+    with patch(
+        "custom_components.blitzortung.geo_location.asyncio.sleep",
+        new=sleep_mock,
+    ):
+        # Must not raise.
+        await _async_batched_service_purge(hass, manager, ids)
+
+    # All 3 chunks were attempted; the failure in chunk 2 didn't abort the loop.
+    assert call_n["i"] == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_geo_location.py
+++ b/tests/test_geo_location.py
@@ -1,0 +1,533 @@
+"""Tests for the Strikes cache, recorder reconcile, and BlitzortungEvent."""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_NAME,
+)
+from homeassistant.core import HomeAssistant, State
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
+
+from custom_components.blitzortung.const import (
+    ATTR_EXTERNAL_ID,
+    ATTR_PUBLICATION_DATE,
+    CONF_CONFIG_TYPE,
+    CONF_MAX_TRACKED_LIGHTNINGS,
+    CONF_RADIUS,
+    CONF_TIME_WINDOW,
+    CONFIG_TYPE_COORDINATES,
+    DOMAIN,
+)
+from custom_components.blitzortung.geo_location import (
+    RECONCILE_INTERVAL,
+    STRIKE_ENTITY_ID_PREFIX,
+    BlitzortungEvent,
+    BlitzortungEventManager,
+    Strikes,
+    _async_reconcile_strikes,
+    _cap_rebuild_to_capacity,
+    _categorise_strikes,
+)
+
+
+@dataclass
+class StrikeStub:
+    """Minimal duck-typed strike: only the _publication_date attr is read."""
+
+    _publication_date: float
+
+
+def _strike(t: float) -> StrikeStub:
+    return StrikeStub(_publication_date=t)
+
+
+# ---------------------------------------------------------------------------
+# Strikes capacity- and time-bounded cache
+# ---------------------------------------------------------------------------
+
+
+def test_insort_below_capacity_returns_empty() -> None:
+    """Adding strikes below capacity evicts nothing."""
+    s = Strikes(capacity=3)
+    assert s.insort(_strike(1.0)) == ()
+    assert s.insort(_strike(2.0)) == ()
+    assert len(s) == 2
+
+
+def test_insort_at_capacity_with_newer_evicts_oldest() -> None:
+    """Once full, a strictly-newer strike evicts the oldest one."""
+    s = Strikes(capacity=2)
+    s.insort(_strike(1.0))
+    s.insort(_strike(2.0))
+    evicted = s.insort(_strike(3.0))
+    assert tuple(e._publication_date for e in evicted) == (1.0,)
+    assert [e._publication_date for e in s] == [2.0, 3.0]
+
+
+def test_insort_at_capacity_with_too_old_strike_is_rejected() -> None:
+    """A strike older than every retained one must not be inserted-then-evicted.
+
+    This is the ghost-entity fix: if we accepted then evicted, the caller
+    would register the entity with HA and immediately fire its delete signal
+    before the entity's listener was attached — leaking the entity forever.
+    """
+    s = Strikes(capacity=2)
+    s.insort(_strike(10.0))
+    s.insort(_strike(20.0))
+    result = s.insort(_strike(5.0))  # older than oldest (10.0)
+    assert result is None
+    # Cache unchanged.
+    assert [e._publication_date for e in s] == [10.0, 20.0]
+
+
+def test_insort_at_capacity_equal_to_oldest_is_rejected() -> None:
+    """Tie with the oldest still gets rejected — no room and not strictly newer."""
+    s = Strikes(capacity=2)
+    s.insort(_strike(10.0))
+    s.insort(_strike(20.0))
+    assert s.insort(_strike(10.0)) is None
+    assert [e._publication_date for e in s] == [10.0, 20.0]
+
+
+def test_insort_at_capacity_with_in_between_key_still_inserts() -> None:
+    """A late strike newer than the oldest still fits — evict oldest, insert."""
+    s = Strikes(capacity=2)
+    s.insort(_strike(10.0))
+    s.insort(_strike(30.0))
+    evicted = s.insort(_strike(20.0))  # newer than 10, older than 30
+    assert tuple(e._publication_date for e in evicted) == (10.0,)
+    assert [e._publication_date for e in s] == [20.0, 30.0]
+
+
+def test_insort_below_capacity_with_out_of_order_key_inserts() -> None:
+    """When there's room, even an out-of-order key is accepted."""
+    s = Strikes(capacity=5)
+    s.insort(_strike(10.0))
+    s.insort(_strike(30.0))
+    assert s.insort(_strike(20.0)) == ()
+    assert [e._publication_date for e in s] == [10.0, 20.0, 30.0]
+
+
+def test_cleanup_removes_strikes_older_than_threshold() -> None:
+    """cleanup(k) evicts every strike with key <= k."""
+    s = Strikes(capacity=10)
+    for t in (1.0, 2.0, 3.0, 4.0, 5.0):
+        s.insort(_strike(t))
+    evicted = s.cleanup(3.0)
+    assert tuple(e._publication_date for e in evicted) == (1.0, 2.0, 3.0)
+    assert [e._publication_date for e in s] == [4.0, 5.0]
+
+
+def test_cleanup_with_no_matching_strikes_returns_empty() -> None:
+    """Cleanup below the oldest strike's key returns nothing."""
+    s = Strikes(capacity=10)
+    s.insort(_strike(10.0))
+    s.insort(_strike(20.0))
+    assert s.cleanup(5.0) == ()
+    assert len(s) == 2
+
+
+def test_cleanup_on_empty_returns_empty() -> None:
+    """Cleanup on an empty cache is a no-op."""
+    s = Strikes(capacity=5)
+    assert s.cleanup(100.0) == ()
+
+
+# ---------------------------------------------------------------------------
+# BlitzortungEvent.from_recorder_state
+# ---------------------------------------------------------------------------
+
+
+def _make_recorder_state(
+    *,
+    entity_id: str = f"{STRIKE_ENTITY_ID_PREFIX}abc123",
+    distance: str = "42.5",
+    latitude: float = 50.0,
+    longitude: float = 10.0,
+    strike_id: str = "abc123",
+    publication_date: datetime | None = None,
+) -> State:
+    pub_date = publication_date or datetime(2026, 5, 26, 12, 0, 0, tzinfo=UTC)
+    return State(
+        entity_id=entity_id,
+        state=distance,
+        attributes={
+            ATTR_LATITUDE: latitude,
+            ATTR_LONGITUDE: longitude,
+            ATTR_EXTERNAL_ID: strike_id,
+            ATTR_PUBLICATION_DATE: pub_date,
+        },
+    )
+
+
+def test_from_recorder_state_reconstructs_event() -> None:
+    """A well-formed recorder state must round-trip into an Event."""
+    state = _make_recorder_state(strike_id="deadbeef")
+    event = BlitzortungEvent.from_recorder_state(state, unit="km")
+    assert event is not None
+    assert event._strike_id == "deadbeef"
+    assert event.entity_id == f"{STRIKE_ENTITY_ID_PREFIX}deadbeef"
+    assert event._attr_distance == 42.5
+    assert event._attr_latitude == 50.0
+    assert event._attr_longitude == 10.0
+    assert event._attr_unit_of_measurement == "km"
+
+
+def test_from_recorder_state_parses_iso_publication_date() -> None:
+    """publication_date may have been serialised to ISO string by recorder."""
+    state = State(
+        entity_id=f"{STRIKE_ENTITY_ID_PREFIX}x",
+        state="10.0",
+        attributes={
+            ATTR_LATITUDE: 50.0,
+            ATTR_LONGITUDE: 10.0,
+            ATTR_EXTERNAL_ID: "x",
+            ATTR_PUBLICATION_DATE: "2026-05-26T12:00:00+00:00",
+        },
+    )
+    event = BlitzortungEvent.from_recorder_state(state, unit="km")
+    assert event is not None
+    assert event._publication_date > 0
+
+
+def test_from_recorder_state_returns_none_on_missing_attrs() -> None:
+    """Corrupt/incomplete state must not raise — just return None."""
+    state = State(
+        entity_id=f"{STRIKE_ENTITY_ID_PREFIX}x",
+        state="unknown",
+        attributes={},
+    )
+    assert BlitzortungEvent.from_recorder_state(state, unit="km") is None
+
+
+def test_from_recorder_state_returns_none_on_unparseable_state() -> None:
+    """Non-numeric state value must not raise."""
+    state = _make_recorder_state(distance="not-a-number")
+    assert BlitzortungEvent.from_recorder_state(state, unit="km") is None
+
+
+# ---------------------------------------------------------------------------
+# Categorise + capacity helpers (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _make_manager(
+    capacity: int = 10, window_seconds: int = 7200
+) -> BlitzortungEventManager:
+    return BlitzortungEventManager(
+        hass=MagicMock(),
+        async_add_entities=MagicMock(),
+        max_tracked_lightnings=capacity,
+        window_seconds=window_seconds,
+    )
+
+
+def test_categorise_skips_live_entries() -> None:
+    """Entities already in the live cache are left alone (daily backstop case)."""
+    manager = _make_manager()
+    live_ev = BlitzortungEvent(
+        distance=10.0,
+        latitude=50.0,
+        longitude=10.0,
+        unit="km",
+        time=int(dt_util.utcnow().timestamp() * 1e9),
+        status=0,
+        region=0,
+        strike_id="live",
+    )
+    manager._strikes.insort(live_ev)
+
+    rebuild, purge = _categorise_strikes(
+        db_entity_ids=[live_ev.entity_id],
+        states_dict={},
+        manager=manager,
+        start_ts=0.0,
+    )
+    assert rebuild == []
+    assert purge == []
+
+
+def test_categorise_purges_entries_with_no_state_in_window() -> None:
+    """An entity_id absent from the recent-states dict is an orphan."""
+    manager = _make_manager()
+    orphan_id = f"{STRIKE_ENTITY_ID_PREFIX}orphan"
+    rebuild, purge = _categorise_strikes(
+        db_entity_ids=[orphan_id],
+        states_dict={},
+        manager=manager,
+        start_ts=0.0,
+    )
+    assert rebuild == []
+    assert purge == [orphan_id]
+
+
+def test_categorise_rebuilds_entries_with_state_in_window() -> None:
+    """A valid state inside the window produces a rebuild candidate."""
+    manager = _make_manager()
+    pub_date = dt_util.utcnow() - timedelta(minutes=10)
+    state = _make_recorder_state(
+        entity_id=f"{STRIKE_ENTITY_ID_PREFIX}fresh",
+        strike_id="fresh",
+        publication_date=pub_date,
+    )
+    rebuild, purge = _categorise_strikes(
+        db_entity_ids=[state.entity_id],
+        states_dict={state.entity_id: [state]},
+        manager=manager,
+        start_ts=(dt_util.utcnow() - timedelta(hours=2)).timestamp(),
+    )
+    assert len(rebuild) == 1
+    assert rebuild[0].entity_id == state.entity_id
+    assert purge == []
+
+
+def test_cap_rebuild_to_capacity_respects_remaining_room() -> None:
+    """Overflow rebuild candidates (newest kept) get queued for purge."""
+    manager = _make_manager(capacity=2)
+    now = dt_util.utcnow().timestamp()
+    events = [
+        BlitzortungEvent(
+            distance=1.0,
+            latitude=50.0,
+            longitude=10.0,
+            unit="km",
+            time=int((now - i) * 1e9),
+            status=0,
+            region=0,
+            strike_id=f"e{i}",
+        )
+        for i in range(5)
+    ]
+    # All five want to come back but capacity is 2; keep the newest two (e0, e1).
+    rebuild, purge = _cap_rebuild_to_capacity(events, [], manager)
+    rebuild_ids = {e.entity_id for e in rebuild}
+    assert len(rebuild) == 2
+    # Newest are at the end of the input list (i=0 is newest in our construction)
+    assert f"{STRIKE_ENTITY_ID_PREFIX}e0" in rebuild_ids
+    assert f"{STRIKE_ENTITY_ID_PREFIX}e1" in rebuild_ids
+    assert len(purge) == 3
+
+
+def test_cap_rebuild_to_capacity_dumps_all_when_cache_already_full() -> None:
+    """If the live cache is at capacity, every candidate goes to purge."""
+    manager = _make_manager(capacity=1)
+    manager._strikes.insort(
+        BlitzortungEvent(
+            distance=1.0,
+            latitude=50.0,
+            longitude=10.0,
+            unit="km",
+            time=int(dt_util.utcnow().timestamp() * 1e9),
+            status=0,
+            region=0,
+            strike_id="live",
+        )
+    )
+    candidate = BlitzortungEvent(
+        distance=2.0,
+        latitude=50.0,
+        longitude=10.0,
+        unit="km",
+        time=int(dt_util.utcnow().timestamp() * 1e9),
+        status=0,
+        region=0,
+        strike_id="extra",
+    )
+    rebuild, purge = _cap_rebuild_to_capacity([candidate], [], manager)
+    assert rebuild == []
+    assert purge == [candidate.entity_id]
+
+
+# ---------------------------------------------------------------------------
+# _async_reconcile_strikes — integration with mocked recorder
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(entry_id: str = "test_entry") -> MockConfigEntry:
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id=entry_id,
+        data={
+            CONF_NAME: "Test",
+            CONF_LATITUDE: 50.0,
+            CONF_LONGITUDE: 10.0,
+            CONF_CONFIG_TYPE: CONFIG_TYPE_COORDINATES,
+        },
+        unique_id=f"50.0-10.0-{entry_id}",
+        version=6,
+        options={
+            CONF_RADIUS: 100,
+            CONF_MAX_TRACKED_LIGHTNINGS: 100,
+            CONF_TIME_WINDOW: 120,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skipped_when_other_entry_loaded(
+    hass: HomeAssistant,
+) -> None:
+    """A sibling Blitzortung entry being loaded must short-circuit reconcile."""
+    entry_a = _make_entry("a")
+    entry_b = _make_entry("b")
+    entry_a.add_to_hass(hass)
+    entry_b.add_to_hass(hass)
+    entry_a.mock_state(hass, ConfigEntryState.LOADED)
+
+    manager = _make_manager()
+    with patch(
+        "custom_components.blitzortung.geo_location."
+        "_async_enumerate_strike_entity_ids",
+        new=AsyncMock(),
+    ) as enumerate_mock:
+        await _async_reconcile_strikes(hass, entry_b, manager)
+    enumerate_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skipped_when_recorder_not_loaded(
+    hass: HomeAssistant,
+) -> None:
+    """Without recorder, reconcile cannot fetch state; must short-circuit."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+    manager = _make_manager()
+    with patch(
+        "custom_components.blitzortung.geo_location."
+        "_async_enumerate_strike_entity_ids",
+        new=AsyncMock(),
+    ) as enumerate_mock:
+        await _async_reconcile_strikes(hass, entry, manager)
+    enumerate_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_purges_orphans_with_explicit_entity_id_list(
+    hass: HomeAssistant,
+) -> None:
+    """Orphans (in DB, no state inside window) get purged precisely by ID list."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+    manager = _make_manager()
+
+    orphan_a = f"{STRIKE_ENTITY_ID_PREFIX}aaa"
+    orphan_b = f"{STRIKE_ENTITY_ID_PREFIX}bbb"
+
+    purge_mock = AsyncMock()
+    hass.services.async_register("recorder", "purge_entities", purge_mock)
+
+    with (
+        patch.object(hass.config, "components", {*hass.config.components, "recorder"}),
+        patch(
+            "custom_components.blitzortung.geo_location.recorder_get_instance",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_enumerate_strike_entity_ids",
+            new=AsyncMock(return_value=[orphan_a, orphan_b]),
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location._async_fetch_strike_states",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        await _async_reconcile_strikes(hass, entry, manager)
+
+    purge_mock.assert_called_once()
+    call_data = purge_mock.call_args.args[0].data
+    assert set(call_data["entity_id"]) == {orphan_a, orphan_b}
+
+
+@pytest.mark.asyncio
+async def test_reconcile_rebuilds_within_window_strikes(
+    hass: HomeAssistant,
+) -> None:
+    """Strikes with state inside the window get reconstructed and registered."""
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+    add_entities_mock = MagicMock()
+    manager = BlitzortungEventManager(
+        hass=hass,
+        async_add_entities=add_entities_mock,
+        max_tracked_lightnings=10,
+        window_seconds=7200,
+    )
+
+    fresh_id = f"{STRIKE_ENTITY_ID_PREFIX}fresh"
+    fresh_state = _make_recorder_state(
+        entity_id=fresh_id,
+        strike_id="fresh",
+        publication_date=dt_util.utcnow() - timedelta(minutes=5),
+    )
+
+    purge_mock = AsyncMock()
+    hass.services.async_register("recorder", "purge_entities", purge_mock)
+
+    with (
+        patch.object(hass.config, "components", {*hass.config.components, "recorder"}),
+        patch(
+            "custom_components.blitzortung.geo_location.recorder_get_instance",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_enumerate_strike_entity_ids",
+            new=AsyncMock(return_value=[fresh_id]),
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location._async_fetch_strike_states",
+            new=AsyncMock(return_value={fresh_id: [fresh_state]}),
+        ),
+    ):
+        await _async_reconcile_strikes(hass, entry, manager)
+
+    # Strike is in the live cache after reconcile.
+    assert any(ev.entity_id == fresh_id for ev in manager._strikes)
+    # Entity was registered with HA.
+    add_entities_mock.assert_called_once()
+    registered = add_entities_mock.call_args.args[0]
+    assert any(ev.entity_id == fresh_id for ev in registered)
+    # Nothing to purge.
+    purge_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Daily periodic reconcile
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_periodic_reconcile_fires_on_interval(
+    hass: HomeAssistant,
+    mock_config_entry_coordinates: MockConfigEntry,
+    mock_mqtt: MagicMock,
+) -> None:
+    """The daily backstop sweep must fire on its interval after setup."""
+    with patch(
+        "custom_components.blitzortung.geo_location._async_reconcile_strikes",
+        new=AsyncMock(),
+    ) as reconcile_mock:
+        await hass.config_entries.async_setup(mock_config_entry_coordinates.entry_id)
+        await hass.async_block_till_done()
+        # Initial reconcile at setup.
+        assert reconcile_mock.call_count == 1
+
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + RECONCILE_INTERVAL + timedelta(seconds=1)
+        )
+        await hass.async_block_till_done()
+
+    assert reconcile_mock.call_count == 2

--- a/tests/test_geo_location.py
+++ b/tests/test_geo_location.py
@@ -32,6 +32,7 @@ from custom_components.blitzortung.const import (
 )
 from custom_components.blitzortung.geo_location import (
     RECONCILE_INTERVAL,
+    RECONCILE_REBUILD_THRESHOLD,
     STRIKE_ENTITY_ID_PREFIX,
     BlitzortungEvent,
     BlitzortungEventManager,
@@ -502,6 +503,57 @@ async def test_reconcile_rebuilds_within_window_strikes(
     assert any(ev.entity_id == fresh_id for ev in registered)
     # Nothing to purge.
     purge_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_fast_path_when_db_exceeds_threshold(
+    hass: HomeAssistant,
+) -> None:
+    """Huge DBs must skip the rebuild path and use a glob purge instead.
+
+    The categorise loop is O(N) on the main thread, and a multi-million-entry
+    WHERE IN query into the recorder can hang its executor. The fast path
+    keeps the integration responsive at the cost of one boot without map
+    continuity.
+    """
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+    manager = _make_manager(window_seconds=7200)
+
+    huge_id_list = [
+        f"{STRIKE_ENTITY_ID_PREFIX}{i:08x}"
+        for i in range(RECONCILE_REBUILD_THRESHOLD + 1)
+    ]
+
+    purge_mock = AsyncMock()
+    hass.services.async_register("recorder", "purge_entities", purge_mock)
+    fetch_mock = AsyncMock(return_value={})
+
+    with (
+        patch.object(hass.config, "components", {*hass.config.components, "recorder"}),
+        patch(
+            "custom_components.blitzortung.geo_location.recorder_get_instance",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_enumerate_strike_entity_ids",
+            new=AsyncMock(return_value=huge_id_list),
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location._async_fetch_strike_states",
+            new=fetch_mock,
+        ),
+    ):
+        await _async_reconcile_strikes(hass, entry, manager)
+
+    # Bulk state fetch (the heavy O(N) categorise input) was NOT called.
+    fetch_mock.assert_not_called()
+    # Purge fell back to the glob path, not an explicit per-entity list.
+    purge_mock.assert_called_once()
+    call_data = purge_mock.call_args.args[0].data
+    assert call_data["entity_globs"] == [f"{STRIKE_ENTITY_ID_PREFIX}*"]
+    assert call_data["keep_days"] >= 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_geo_location.py
+++ b/tests/test_geo_location.py
@@ -579,10 +579,13 @@ async def test_batched_service_purge_drains_via_cursor_until_empty(
     ]
 
     call_log: list[list[str]] = []
+    max_metadata_id = all_rows[-1][0]
 
-    async def fake_enumerate(_inst: object, after: int, limit: int) -> list:
-        # Return rows with metadata_id > after, up to limit.
-        return [r for r in all_rows if r[0] > after][:limit]
+    async def fake_enumerate(
+        _inst: object, after: int, limit: int, upper: int,
+    ) -> list:
+        # Return rows in (after, upper] up to limit.
+        return [r for r in all_rows if after < r[0] <= upper][:limit]
 
     purge_mock = AsyncMock(
         side_effect=lambda call: call_log.append(list(call.data["entity_id"])),
@@ -595,6 +598,11 @@ async def test_batched_service_purge_drains_via_cursor_until_empty(
             "custom_components.blitzortung.geo_location."
             "_async_enumerate_strike_chunk",
             new=fake_enumerate,
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_get_max_strike_metadata_id",
+            new=AsyncMock(return_value=max_metadata_id),
         ),
         patch(
             "custom_components.blitzortung.geo_location.asyncio.sleep",
@@ -633,8 +641,10 @@ async def test_batched_service_purge_continues_after_chunk_failure(
         (i + 1, f"{STRIKE_ENTITY_ID_PREFIX}{i:08x}") for i in range(total)
     ]
 
-    async def fake_enumerate(_inst: object, after: int, limit: int) -> list:
-        return [r for r in all_rows if r[0] > after][:limit]
+    async def fake_enumerate(
+        _inst: object, after: int, limit: int, upper: int,
+    ) -> list:
+        return [r for r in all_rows if after < r[0] <= upper][:limit]
 
     call_n = {"i": 0}
 
@@ -651,6 +661,11 @@ async def test_batched_service_purge_continues_after_chunk_failure(
             "custom_components.blitzortung.geo_location."
             "_async_enumerate_strike_chunk",
             new=fake_enumerate,
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_get_max_strike_metadata_id",
+            new=AsyncMock(return_value=all_rows[-1][0]),
         ),
         patch(
             "custom_components.blitzortung.geo_location.asyncio.sleep",
@@ -671,7 +686,9 @@ async def test_batched_service_purge_uses_window_for_keep_days(
     instance = MagicMock()
 
     # Single chunk only — set up empty enumeration after the first slice.
-    async def fake_enumerate_once(_inst: object, after: int, limit: int) -> list:
+    async def fake_enumerate_once(
+        _inst: object, after: int, limit: int, upper: int,
+    ) -> list:
         if after == 0:
             return [(1, f"{STRIKE_ENTITY_ID_PREFIX}aa")]
         return []
@@ -684,6 +701,11 @@ async def test_batched_service_purge_uses_window_for_keep_days(
             "custom_components.blitzortung.geo_location."
             "_async_enumerate_strike_chunk",
             new=fake_enumerate_once,
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_get_max_strike_metadata_id",
+            new=AsyncMock(return_value=1),
         ),
         patch(
             "custom_components.blitzortung.geo_location.asyncio.sleep",
@@ -709,6 +731,66 @@ async def test_batched_service_purge_uses_window_for_keep_days(
             hass, instance, _make_manager(window_seconds=2 * 3600), 1
         )
         assert purge_mock.call_args.args[0].data["keep_days"] == 0
+
+
+@pytest.mark.asyncio
+async def test_batched_service_purge_does_not_eat_live_strikes(
+    hass: HomeAssistant,
+) -> None:
+    """The cleanup loop must skip strikes that arrive after it began.
+
+    Without an upper bound, the cursor would walk past its starting set
+    and start purging MQTT-delivered live strikes — keeping the map
+    permanently empty during active weather.
+    """
+    instance = MagicMock()
+    manager = _make_manager(window_seconds=7200)
+
+    # At cleanup-start, states_meta has metadata_ids 1..100.
+    # New strikes during cleanup get ids 101+ — they must NOT be purged.
+    pre_existing = [
+        (i + 1, f"{STRIKE_ENTITY_ID_PREFIX}old{i:08x}") for i in range(100)
+    ]
+    arrived_during = [
+        (101 + i, f"{STRIKE_ENTITY_ID_PREFIX}new{i:08x}") for i in range(50)
+    ]
+    all_rows = pre_existing + arrived_during
+
+    queued_ids: list[str] = []
+
+    async def fake_enumerate(
+        _inst: object, after: int, limit: int, upper: int,
+    ) -> list:
+        return [r for r in all_rows if after < r[0] <= upper][:limit]
+
+    purge_mock = AsyncMock(
+        side_effect=lambda call: queued_ids.extend(call.data["entity_id"]),
+    )
+    hass.services.async_register("recorder", "purge_entities", purge_mock)
+
+    with (
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_enumerate_strike_chunk",
+            new=fake_enumerate,
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location."
+            "_async_get_max_strike_metadata_id",
+            new=AsyncMock(return_value=100),  # snapshot at start
+        ),
+        patch(
+            "custom_components.blitzortung.geo_location.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+    ):
+        await _async_batched_service_purge(hass, instance, manager, 100)
+
+    # All 100 pre-existing ids were queued for purge.
+    assert len(queued_ids) == 100
+    assert all("old" in eid for eid in queued_ids)
+    # None of the 50 new ones were touched.
+    assert not any("new" in eid for eid in queued_ids)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -399,6 +399,34 @@ async def test_async_setup_entry_imperial_system(
     assert coordinator.radius > 150
 
 
+async def test_async_setup_entry_warns_on_empty_geohash(
+    hass: HomeAssistant,
+    mock_config_entry_coordinates: MockConfigEntry,
+    mock_mqtt: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """When geohash_overlap returns empty, a WARNING must surface the silent break."""
+    # Mock geohash_overlap to return empty (simulates radius too large)
+    with patch(
+        "custom_components.blitzortung.geohash_overlap",
+        return_value=set(),
+    ):
+        await hass.config_entries.async_setup(
+            mock_config_entry_coordinates.entry_id
+        )
+        await hass.async_block_till_done()
+
+    assert mock_config_entry_coordinates.state is ConfigEntryState.LOADED
+    # The integration setup proceeds (MQTT connects, sensors register) but the
+    # operator gets a loud warning that no strikes will arrive.
+    assert any(
+        "No geohash tiles" in record.message
+        and "NO STRIKES WILL ARRIVE" in record.message
+        for record in caplog.records
+        if record.levelname == "WARNING"
+    )
+
+
 async def test_async_update_options_reloads_entry(
     hass: HomeAssistant,
     mock_config_entry_coordinates: MockConfigEntry,


### PR DESCRIPTION
## Why

The Blitzortung integration creates a `geo_location.lightning_strike_*` entity per detected strike (UUID-based entity_id) and removes it after the configured `time_window` expires via the dispatcher signal in `BlitzortungEvent._delete_callback`. That works fine during steady-state operation.

What breaks: **when HA stops** (reboot, container restart, crash), in-flight strikes never get their `async_remove(force_remove=True)` called. Their last `state_changed` event was the initial creation; no termination event is ever recorded. The rows sit in the recorder DB until normal retention purges them — often 6+ months on user configs. On a national-scale install (5000-strike cache, active weather, 180-day retention), this accumulates **millions of orphan rows**.

There's also a related but smaller bug: when the in-memory `Strikes` cache is at capacity and a strike arrives with a timestamp older than every retained strike, the cache inserts it then immediately evicts it. The eviction signal fires before `async_added_to_hass` has attached the listener → the entity sticks in HA forever, also as an orphan.

## What this PR does

### 1. Reconcile recorder state with in-memory cache at integration setup

`_async_reconcile_strikes` runs as a background task in `geo_location.async_setup_entry`. Strategy depends on DB size:

- **Below `RECONCILE_REBUILD_THRESHOLD` (10,000 entries):** rebuild. Bulk-fetch the last state per strike via `recorder.history.get_significant_states`, reconstruct `BlitzortungEvent` objects for those still within `time_window` (re-using their original `entity_id` / `external_id` so recorder history continuity is preserved), and add them to HA. Normal `tick()` then evicts them as their time expires, generating the proper `state_changed` removal records. Side effect: **the lightning map survives HA restart** instead of going dark until new strikes arrive. Strikes past the window are precisely purged via `recorder.purge_entities` with their explicit entity_id list.

- **Above the threshold:** skip rebuild and drain via chunked `recorder.purge_entities` calls. A single glob purge on a multi-million-entity DB was observed to (a) hang the recorder executor for very long stretches (it Python-iterates the full `states_meta` table per task) and (b) drop the MariaDB connection at scale. Chunks of 350 entity_ids each with a 1s asyncio.sleep between keeps the recorder responsive and stays under `MAX_EVENT_DATA_BYTES` (32 KB) for the `call_service` event payload.

A daily backstop reruns the reconcile against the live cache.

### 2. Cursor-paged enumeration with upper bound

Each chunk freshly queries the next slice of `states_meta` via `metadata_id > cursor AND metadata_id <= upper_bound`, ordered ascending. The cursor advances monotonically (no revisits, no stale snapshot). The upper bound is `max(metadata_id)` captured at cleanup start — without it, new strikes arriving from MQTT during the drain get caught and purged too, keeping the map permanently empty during active weather.

### 3. Late-arriving-strike ghost fix

`Strikes.insort` now returns `None` (rejection) when at capacity and the key is `<=` the oldest retained strike. `lightning_cb` short-circuits on `None` — no entity added to HA, no eviction signal fired. Return type narrowed from `list[slice]` to `tuple[Event, ...]`.

### 4. Warn when geohash_overlap returns empty

`geohash_overlap()` silently returns `set()` for radii whose bounding box exceeds precision-1 tile coverage (~6700 km at mid-latitudes). The integration would set up cleanly, MQTT connects, sensors register — but no topics are ever subscribed and no strikes ever arrive. Now logs a loud `WARNING` at both initial setup and on location-change refresh, naming the cause and suggesting remediation.

### 5. Operational logging

INFO-level reconcile detection counts at the start and end of each pass — operators on production DBs can see what was found, rebuilt, purged, and skipped.

## Backward compatibility

- No schema migration. Existing config entries work as-is.
- No options changes.
- Behavior change: lightning strikes from before HA restart now reappear on the map (within their `time_window`) instead of vanishing. The integration was previously losing them silently.
- Recorder service interactions use only documented HA APIs (`recorder.purge_entities` service + `recorder.history.get_significant_states`). The one place we reach into recorder internals is `StatesMeta` for enumeration — same query pattern `recorder.purge_entities` uses internally — bounded by `try/except` so a schema change degrades to "no cleanup this boot" rather than an error.

## Testing

23 new tests in `tests/test_geo_location.py` covering:
- `Strikes` insort/cleanup including the rejection path
- `BlitzortungEvent.from_recorder_state` round-trip and failure modes
- Cursor-paged enumeration with upper bound
- Chunked service purge: chunking, sleeps, failure handling, live-strike protection
- `keep_days` derivation from `time_window`
- Periodic backstop scheduling
- Multi-entry skip behavior

Plus a new test in `tests/test_init.py` for the empty-geohash warning.

All tests pass. Manual stress-tested on a production install at 5000-strike cache with ~2M orphan rows accumulated — cleanup drains predictably without blocking HA setup, live strikes continue to arrive.

## Stats

```
4 files changed, 1420 insertions(+), 9 deletions(-)
```
