### PR TITLE
Add missing PR Labels verification workflow

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,28 @@
+name: PR Labels
+
+permissions:
+  contents: read
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+  workflow_call:
+
+jobs:
+  pr_labels:
+    name: Verify label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify PR has a valid label
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          pull-request-number: "${{ github.event.pull_request.number }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          valid-labels: >-
+            breaking-change, bugfix, documentation, enhancement, tests,
+            refactor, performance, new-feature, maintenance, ci, dependencies
+          disable-reviews: true


### PR DESCRIPTION
I forgot about this in https://github.com/mrk-its/homeassistant-blitzortung/pull/290